### PR TITLE
Skip splitter cache build without accepted vehicles

### DIFF
--- a/src/splitter.ts
+++ b/src/splitter.ts
@@ -219,13 +219,19 @@ export const initializeSplitting = async (
     feedMap
   );
 
-  await buildUpCache(
-    logger,
-    vehicleStateCache,
-    cacheReader,
-    cacheWindowInSeconds,
-    feedMap
-  );
+  if (acceptedVehicles.size > 0) {
+    await buildUpCache(
+      logger,
+      vehicleStateCache,
+      cacheReader,
+      cacheWindowInSeconds,
+      feedMap
+    );
+  } else {
+    logger.warn(
+      "Skipping startup cache build because no accepted vehicles were found"
+    );
+  }
 
   const updateVehicleRegistryCache = (vrPulsarMessage: Pulsar.Message) => {
     updateAcceptedVehicles(logger, vrPulsarMessage, feedMap, acceptedVehicles);


### PR DESCRIPTION
## Summary
- skip startup cache rebuild when vehicle catalogue startup read finds no accepted vehicles
- keep live vehicle-registry reader active so later valid catalogue messages can populate accepted vehicles

## Verification
- npm test -- --runInBand
- npm run ts:check
- npm run eslint
- npm run build
- npm run prettier:check