### PR TITLE
Fix splitter startup cache replay

### DIFF
--- a/src/cacheBuilding.ts
+++ b/src/cacheBuilding.ts
@@ -35,7 +35,11 @@ export const getFeedDetails = (
   | undefined => {
   let result;
   const feedPublisherId =
-    feedMap.get(topic) ?? feedMap.get(topic.replace("/splitted-", "/"));
+    feedMap.get(topic) ??
+    feedMap.get(topic.replace("/splitted-", "/")) ??
+    (topic.length === 0 && feedMap.size === 1
+      ? feedMap.values().next().value
+      : undefined);
   if (feedPublisherId !== undefined) {
     result = {
       feedPublisherId,
@@ -43,6 +47,15 @@ export const getFeedDetails = (
   }
   return result;
 };
+
+const getMessageLogContext = (message: Pulsar.Message) => ({
+  pulsarTopic: message.getTopicName(),
+  messageID: message.getMessageId().toString(),
+  dataSize: message.getData().length,
+  eventTimestamp: message.getEventTimestamp(),
+  publishTimestamp: message.getPublishTimestamp?.() ?? 0,
+  properties: { ...message.getProperties() },
+});
 
 export const getUniqueVehicleIdFromVehicleApcMapping = (
   vehicleApcMapping: VehicleApcMapping.VehicleApcMapping,
@@ -134,7 +147,6 @@ export const buildUpCache = async (
           break;
         }
 
-        const dataString = cacheMessage.getData().toString("utf8");
         let canProcess = true;
         let feedMessage: transit_realtime.FeedMessage | undefined;
         try {
@@ -145,9 +157,7 @@ export const buildUpCache = async (
           logger.warn(
             {
               err,
-              cacheMessageDataString: dataString,
-              eventTimestamp: cacheMessage.getEventTimestamp(),
-              properties: { ...cacheMessage.getProperties() },
+              cacheMessage: getMessageLogContext(cacheMessage),
             },
             "Could not parse cacheMessage"
           );
@@ -157,9 +167,7 @@ export const buildUpCache = async (
         if (canProcess && feedMessage?.entity[0] == null) {
           logger.warn(
             {
-              cacheMessageDataString: dataString,
-              eventTimestamp: cacheMessage.getEventTimestamp(),
-              properties: { ...cacheMessage.getProperties() },
+              cacheMessage: getMessageLogContext(cacheMessage),
             },
             "Cache message does not contain a feed entity"
           );
@@ -171,9 +179,7 @@ export const buildUpCache = async (
           if (entity0 == null) {
             logger.warn(
               {
-                cacheMessageDataString: dataString,
-                eventTimestamp: cacheMessage.getEventTimestamp(),
-                properties: { ...cacheMessage.getProperties() },
+                cacheMessage: getMessageLogContext(cacheMessage),
               },
               "Cache message does not contain a feed entity"
             );
@@ -185,9 +191,8 @@ export const buildUpCache = async (
             if (feedDetails == null) {
               logger.warn(
                 {
-                  cacheMessageDataString: dataString,
-                  eventTimestamp: cacheMessage.getEventTimestamp(),
-                  properties: { ...cacheMessage.getProperties() },
+                  cacheMessage: getMessageLogContext(cacheMessage),
+                  feedMap: [...feedmap.entries()],
                 },
                 "Could not get feed details from the Pulsar topic name"
               );
@@ -207,9 +212,7 @@ export const buildUpCache = async (
               } else {
                 logger.warn(
                   {
-                    cacheMessageDataString: dataString,
-                    eventTimestamp: cacheMessage.getEventTimestamp(),
-                    properties: { ...cacheMessage.getProperties() },
+                    cacheMessage: getMessageLogContext(cacheMessage),
                   },
                   "Could not get uniqueVehicleId or timestamp from the cacheMessage"
                 );

--- a/src/splitter.ts
+++ b/src/splitter.ts
@@ -211,15 +211,23 @@ export const initializeSplitting = async (
   const acceptedVehicles: AcceptedVehicles = new Set<UniqueVehicleId>();
   logger.info("Initializing splitting");
 
+  const vehicleRegistryWindowInSeconds =
+    cacheWindowInSeconds > 0 ? cacheWindowInSeconds : 172800;
+
   await buildAcceptedVehicles(
     logger,
     acceptedVehicles,
     vehicleReader,
-    cacheWindowInSeconds,
+    vehicleRegistryWindowInSeconds,
     feedMap
   );
 
-  if (acceptedVehicles.size > 0) {
+  if (cacheWindowInSeconds <= 0) {
+    logger.warn(
+      { cacheWindowInSeconds },
+      "Skipping startup cache build because cache window is disabled"
+    );
+  } else if (acceptedVehicles.size > 0) {
     await buildUpCache(
       logger,
       vehicleStateCache,


### PR DESCRIPTION
Fixes the prod splitter startup failure seen on 2026-05-24.\n\nChanges:\n- allow startup cache replay to be disabled with CACHE_WINDOW_IN_SECONDS=0\n- keep vehicle-registry warmup on the normal 48h window when replay is disabled\n- avoid logging raw binary GTFS-RT payloads from cache replay warnings\n- fall back to the sole feed map entry when Pulsar reader messages have an empty topic name\n\nVerified locally:\n- npm test -- --runInBand\n- npm run ts:check\n- npm run build:src\n- docker build --target production