### PR TITLE
Limit splitter registry warmup when replay is disabled

### DIFF
--- a/src/splitter.ts
+++ b/src/splitter.ts
@@ -212,7 +212,7 @@ export const initializeSplitting = async (
   logger.info("Initializing splitting");
 
   const vehicleRegistryWindowInSeconds =
-    cacheWindowInSeconds > 0 ? cacheWindowInSeconds : 172800;
+    cacheWindowInSeconds > 0 ? cacheWindowInSeconds : 600;
 
   await buildAcceptedVehicles(
     logger,


### PR DESCRIPTION
Follow-up to #634 after the first fixed image failed in prod.\n\nWhen CACHE_WINDOW_IN_SECONDS=0, startup GTFS-RT cache replay is disabled, but the vehicle registry warmup should also stay bounded. This keeps the registry warmup at 10 minutes, matching the live prod mitigation, instead of replaying 48 hours.\n\nVerified locally:\n- npm test -- --runInBand\n- npm run ts:check\n- npm run build:src