### PR TITLE
Make splitter Pulsar reads timeout configurable

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -58,11 +58,16 @@ export interface CacheRebuildConfig {
   cacheWindowInSeconds: number;
 }
 
+export interface MessageProcessingConfig {
+  pulsarReadTimeoutMs: number;
+}
+
 export interface Config {
   processing: ProcessingConfig;
   pulsar: PulsarConfig;
   healthCheck: HealthCheckConfig;
   cacheRebuildConfig: CacheRebuildConfig;
+  messageProcessingConfig: MessageProcessingConfig;
 }
 
 const getRequired = (envVariable: string) => {
@@ -229,6 +234,14 @@ const getCacheRebuildConfig = () => {
   };
 };
 
+const getMessageProcessingConfig = () => {
+  const pulsarReadTimeoutMs =
+    getOptionalNonNegativeFloat("PULSAR_READ_TIMEOUT_MS") ?? 300_000;
+  return {
+    pulsarReadTimeoutMs,
+  };
+};
+
 const getPulsarConfig = (logger: pino.Logger): PulsarConfig => {
   const oauth2Config = getPulsarOauth2Config();
   const serviceUrl = getRequired("PULSAR_SERVICE_URL");
@@ -293,6 +306,7 @@ const getHealthCheckConfig = () => {
 export const getConfig = (logger: pino.Logger): Config => ({
   processing: getProcessingConfig(),
   cacheRebuildConfig: getCacheRebuildConfig(),
+  messageProcessingConfig: getMessageProcessingConfig(),
   pulsar: getPulsarConfig(logger),
   healthCheck: getHealthCheckConfig(),
 });

--- a/src/index.ts
+++ b/src/index.ts
@@ -205,7 +205,8 @@ const exitGracefully = async (
         vrReader,
         cacheReader,
         config.processing,
-        config.cacheRebuildConfig
+        config.cacheRebuildConfig,
+        config.messageProcessingConfig
       );
     } catch (err) {
       exitHandler(1, transformUnknownToError(err));

--- a/src/messageProcessing.ts
+++ b/src/messageProcessing.ts
@@ -1,14 +1,17 @@
 import type pino from "pino";
 import type Pulsar from "pulsar-client";
-import type { ProcessingConfig, CacheRebuildConfig } from "./config";
+import type {
+  ProcessingConfig,
+  CacheRebuildConfig,
+  MessageProcessingConfig,
+} from "./config";
 import { initializeSplitting } from "./splitter";
-
-const PULSAR_READ_TIMEOUT_MS = 300_000;
 
 const keepReactingToGtfsrt = async (
   logger: pino.Logger,
   producer: Pulsar.Producer,
   gtfsrtConsumer: Pulsar.Consumer,
+  pulsarReadTimeoutMs: number,
   splitVehiclesAndSend: (
     gtfsrtMessage: Pulsar.Message,
     sendCallback: (
@@ -22,12 +25,10 @@ const keepReactingToGtfsrt = async (
   for (;;) {
     let gtfsrtPulsarMessage: Pulsar.Message | undefined;
     try {
-      gtfsrtPulsarMessage = await gtfsrtConsumer.receive(
-        PULSAR_READ_TIMEOUT_MS
-      );
+      gtfsrtPulsarMessage = await gtfsrtConsumer.receive(pulsarReadTimeoutMs);
     } catch (err) {
       logger.warn(
-        { err, readTimeoutMs: PULSAR_READ_TIMEOUT_MS },
+        { err, readTimeoutMs: pulsarReadTimeoutMs },
         "GTFS-RT consumer receive failed"
       );
     }
@@ -70,16 +71,17 @@ const keepReactingToGtfsrt = async (
 const keepReadingVehicleRegistry = async (
   logger: pino.Logger,
   vrReader: Pulsar.Reader,
+  pulsarReadTimeoutMs: number,
   updateVehicleRegistryCache: (apcMessage: Pulsar.Message) => void
 ): Promise<void> => {
   // Errors are handled on the main level.
   for (;;) {
     let vrMessage: Pulsar.Message | undefined;
     try {
-      vrMessage = await vrReader.readNext(PULSAR_READ_TIMEOUT_MS);
+      vrMessage = await vrReader.readNext(pulsarReadTimeoutMs);
     } catch (err) {
       logger.warn(
-        { err, readTimeoutMs: PULSAR_READ_TIMEOUT_MS },
+        { err, readTimeoutMs: pulsarReadTimeoutMs },
         "Vehicle registry reader read failed"
       );
     }
@@ -97,8 +99,10 @@ const keepProcessingMessages = async (
   vrReader: Pulsar.Reader,
   cacheReader: Pulsar.Reader,
   processingConfig: ProcessingConfig,
-  cacheConfig: CacheRebuildConfig
+  cacheConfig: CacheRebuildConfig,
+  messageProcessingConfig: MessageProcessingConfig
 ): Promise<void> => {
+  const { pulsarReadTimeoutMs } = messageProcessingConfig;
   const { updateVehicleRegistryCache, splitVehiclesAndSend } =
     await initializeSplitting(
       logger,
@@ -112,9 +116,15 @@ const keepProcessingMessages = async (
       logger,
       producer,
       gtfsrtConsumer,
+      pulsarReadTimeoutMs,
       splitVehiclesAndSend
     ),
-    keepReadingVehicleRegistry(logger, vrReader, updateVehicleRegistryCache),
+    keepReadingVehicleRegistry(
+      logger,
+      vrReader,
+      pulsarReadTimeoutMs,
+      updateVehicleRegistryCache
+    ),
   ];
   // We expect both promises to stay pending.
   await Promise.all(promises);


### PR DESCRIPTION
Make vehicle-position-splitter Pulsar read timeouts configurable via PULSAR_READ_TIMEOUT_MS.

Root cause: splitters can sit healthy while Pulsar receive/read calls stop making progress. In prod this left Lahti/Kuopio connected but not producing split GTFS-RT messages, so journey-matcher had no fresh vehicle-position input.

Changes: add messageProcessingConfig, parse PULSAR_READ_TIMEOUT_MS with a 300000 ms default, and pass it into GTFS-RT consumer receive and vehicle-registry reader readNext calls.

Validation: npm run check-and-build
