### PR TITLE
Disable splitter image provenance attestations

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -72,3 +72,4 @@ jobs:
           target: "${{ env.PRODUCTION_STAGE }}"
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
+          provenance: false


### PR DESCRIPTION
GKE pulled the pushed splitter image by digest as an OCI index with attestation entries and the resulting pod failed with missing /home/node/app/dist/index.js. Disable build provenance on the Docker Hub push so deployments can pin a plain runtime image digest.