### PR TITLE
Run splitter from app dir owned by runtime UID

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -52,18 +52,19 @@ RUN apt-get update \
   && apt-get -y --no-install-recommends install \
   'ca-certificates' \
   'tini' \
-  && rm -rf /var/lib/apt/lists/*
+  && rm -rf /var/lib/apt/lists/* \
+  && mkdir /app \
+  && chown 10001:10001 /app
 
-USER node
-RUN mkdir /home/node/app
-WORKDIR /home/node/app
+USER 10001:10001
+WORKDIR /app
 COPY \
-  --chown=node:node \
+  --chown=10001:10001 \
   --from=builder \
   /home/node/app/dist \
   ./dist
 COPY \
-  --chown=node:node \
+  --chown=10001:10001 \
   --from=node_modules \
   /home/node/app/node_modules \
   ./node_modules


### PR DESCRIPTION
## Summary
- move the production image runtime workdir from /home/node/app to /app
- own /app as UID/GID 10001, matching the Kubernetes securityContext
- keeps the image readable when node:26 has restrictive /home/node permissions

## Verification
- npm test -- --runInBand
- npm run ts:check
- docker build --target production -t waltti-apc-vehicle-position-splitter:uid10001-test .
- docker run --rm --network none waltti-apc-vehicle-position-splitter:uid10001-test reaches application startup and fails only on missing FEED_MAP