### PR TITLE
Avoid timed vehicle registry reader reads

### DIFF
--- a/src/cacheBuilding.ts
+++ b/src/cacheBuilding.ts
@@ -390,24 +390,14 @@ export const buildAcceptedVehicles = async (
   await vehicleReader.seekTimestamp(startTime);
   logger.debug("Seeked to start time");
   let cacheMessage: Pulsar.Message | undefined;
-  try {
-    cacheMessage = await vehicleReader.readNext(pulsarReadTimeoutMs);
-  } catch (err) {
-    logger.warn(
-      { err, readTimeoutMs: pulsarReadTimeoutMs },
-      "Timed out while reading first vehicle registry message"
-    );
+  if (vehicleReader.hasNext()) {
+    cacheMessage = await vehicleReader.readNext();
   }
   if (cacheMessage == null) {
     logger.info("No message found, increasing start time");
     await vehicleReader.seekTimestamp(now - cacheWindowInSeconds * 1000 * 7);
-    try {
-      cacheMessage = await vehicleReader.readNext(pulsarReadTimeoutMs);
-    } catch (err) {
-      logger.warn(
-        { err, readTimeoutMs: pulsarReadTimeoutMs },
-        "Timed out while reading vehicle registry message from increased window"
-      );
+    if (vehicleReader.hasNext()) {
+      cacheMessage = await vehicleReader.readNext();
     }
   }
   if (cacheMessage == null) {
@@ -424,14 +414,9 @@ export const buildAcceptedVehicles = async (
   updateAcceptedVehicles(logger, cacheMessage, feedMap, acceptedVehicles);
   logger.debug("Reading messages");
   while (vehicleReader.hasNext()) {
-    try {
-      // eslint-disable-next-line no-await-in-loop
-      cacheMessage = await vehicleReader.readNext(pulsarReadTimeoutMs);
-      updateAcceptedVehicles(logger, cacheMessage, feedMap, acceptedVehicles);
-    } catch (err) {
-      logger.warn({ err }, "Timeout while reading next message");
-      break;
-    }
+    // eslint-disable-next-line no-await-in-loop
+    cacheMessage = await vehicleReader.readNext();
+    updateAcceptedVehicles(logger, cacheMessage, feedMap, acceptedVehicles);
     logger.debug(cacheMessage.getEventTimestamp(), "Event timestamp");
   }
   logger.debug("Finished reading messages");

--- a/src/messageProcessing.ts
+++ b/src/messageProcessing.ts
@@ -69,25 +69,13 @@ const keepReactingToGtfsrt = async (
 };
 
 const keepReadingVehicleRegistry = async (
-  logger: pino.Logger,
   vrReader: Pulsar.Reader,
-  pulsarReadTimeoutMs: number,
   updateVehicleRegistryCache: (apcMessage: Pulsar.Message) => void
 ): Promise<void> => {
   // Errors are handled on the main level.
   for (;;) {
-    let vrMessage: Pulsar.Message | undefined;
-    try {
-      vrMessage = await vrReader.readNext(pulsarReadTimeoutMs);
-    } catch (err) {
-      logger.warn(
-        { err, readTimeoutMs: pulsarReadTimeoutMs },
-        "Vehicle registry reader read failed"
-      );
-    }
-    if (vrMessage != null) {
-      updateVehicleRegistryCache(vrMessage);
-    }
+    const vrMessage = await vrReader.readNext();
+    updateVehicleRegistryCache(vrMessage);
   }
   /* eslint-enable no-await-in-loop */
 };
@@ -120,12 +108,7 @@ const keepProcessingMessages = async (
       pulsarReadTimeoutMs,
       splitVehiclesAndSend
     ),
-    keepReadingVehicleRegistry(
-      logger,
-      vrReader,
-      pulsarReadTimeoutMs,
-      updateVehicleRegistryCache
-    ),
+    keepReadingVehicleRegistry(vrReader, updateVehicleRegistryCache),
   ];
   // We expect both promises to stay pending.
   await Promise.all(promises);


### PR DESCRIPTION
## Summary
- avoid timed `Reader.readNext(timeout)` calls for vehicle-registry readers
- startup cache building now checks `hasNext()` before untimed `readNext()` so empty registry windows do not block
- live registry updates use an untimed blocking read in their own long-running task

## Why
The timeout-enabled image reached startup under Kubernetes, but prod Kuopio segfaulted (`exit 139`) after the vehicle-registry read timeout. This keeps the startup non-blocking without exercising the native timeout path.

## Verification
- npm test -- --runInBand
- npm run ts:check
- npm run build