### PR TITLE
[codex] Revert protobuf runtime bump in splitter

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,7 @@
         "date-fns": "^4.4.0",
         "date-fns-tz": "^3.2.0",
         "pino": "^8.16.2",
-        "protobufjs": "^8.6.1",
+        "protobufjs": "^8.5.0",
         "pulsar-client": "^1.17.0"
       },
       "devDependencies": {
@@ -31,7 +31,7 @@
         "eslint-plugin-prettier": "^4.0.0",
         "jest": "^30.4.2",
         "prettier": "^2.8.8",
-        "protobufjs-cli": "^2.5.2",
+        "protobufjs-cli": "^2.5.0",
         "quicktype": "^23.2.6",
         "ts-jest": "^29.4.11",
         "typescript": "^5.9.3"
@@ -1361,12 +1361,12 @@
       }
     },
     "node_modules/@jsdoc/salty": {
-      "version": "0.2.12",
-      "resolved": "https://registry.npmjs.org/@jsdoc/salty/-/salty-0.2.12.tgz",
-      "integrity": "sha512-TuB0x50EoAvEX/UEWITd8Mkn3WhiTjSvbTMCLj0BhsQEl5iUzjXdA0bETEVpTk+5TGTLR6QktI9H4hLviVeaAQ==",
+      "version": "0.2.5",
+      "resolved": "https://registry.npmjs.org/@jsdoc/salty/-/salty-0.2.5.tgz",
+      "integrity": "sha512-TfRP53RqunNe2HBobVBJ0VLhK1HbfvBYeTC1ahnN64PWvyYyGebmMiPkuwvD9fpw2ZbkoPb8Q7mwy0aR8Z9rvw==",
       "dev": true,
       "dependencies": {
-        "lodash": "^4.18.1"
+        "lodash": "^4.17.21"
       },
       "engines": {
         "node": ">=v12.0.0"
@@ -1668,25 +1668,25 @@
       "dev": true
     },
     "node_modules/@types/linkify-it": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/@types/linkify-it/-/linkify-it-5.0.0.tgz",
-      "integrity": "sha512-sVDA58zAw4eWAffKOaQH5/5j3XeayukzDk+ewSsnv3p4yJEZHCCzMDiZM8e0OUrRvmpGZ85jf4yDHkHsgBNr9Q==",
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@types/linkify-it/-/linkify-it-3.0.2.tgz",
+      "integrity": "sha512-HZQYqbiFVWufzCwexrvh694SOim8z2d+xJl5UNamcvQFejLY/2YUtzXHYi3cHdI7PMlS8ejH2slRAOJQ32aNbA==",
       "dev": true
     },
     "node_modules/@types/markdown-it": {
-      "version": "14.1.2",
-      "resolved": "https://registry.npmjs.org/@types/markdown-it/-/markdown-it-14.1.2.tgz",
-      "integrity": "sha512-promo4eFwuiW+TfGxhi+0x3czqTYJkG8qB17ZUJiVF10Xm7NLVRSLUsfRTU/6h1e24VvRnXCx+hG7li58lkzog==",
+      "version": "12.2.3",
+      "resolved": "https://registry.npmjs.org/@types/markdown-it/-/markdown-it-12.2.3.tgz",
+      "integrity": "sha512-GKMHFfv3458yYy+v/N8gjufHO6MSZKCOXpZc5GXIWWy8uldwfmPn98vp81gZ5f9SVw8YYBctgfJ22a2d7AOMeQ==",
       "dev": true,
       "dependencies": {
-        "@types/linkify-it": "^5",
-        "@types/mdurl": "^2"
+        "@types/linkify-it": "*",
+        "@types/mdurl": "*"
       }
     },
     "node_modules/@types/mdurl": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@types/mdurl/-/mdurl-2.0.0.tgz",
-      "integrity": "sha512-RGdgjQUZba5p6QEFAVx2OGb8rQDL/cPRG7GiedRzMcJ1tYnUANBncjbSB1NRGwbvjcPeikRABz2nshyPk1bhWg==",
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@types/mdurl/-/mdurl-1.0.2.tgz",
+      "integrity": "sha512-eC4U9MlIcu2q0KQmXszyn5Akca/0jrQmwDRgpAMJai7qBWq4amIQhZyNau4VYGtCeALvW1/NtjzJJ567aZxfKA==",
       "dev": true
     },
     "node_modules/@types/node": {
@@ -3430,13 +3430,10 @@
       "dev": true
     },
     "node_modules/entities": {
-      "version": "4.5.0",
-      "resolved": "https://registry.npmjs.org/entities/-/entities-4.5.0.tgz",
-      "integrity": "sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-2.1.0.tgz",
+      "integrity": "sha512-hCx1oky9PFrJ611mf0ifBLBRW8lUUVRlFolb5gWRfIELabBlbp9xZvrqZLZAs+NxFnbfQoeGd8wDkygjg7U85w==",
       "dev": true,
-      "engines": {
-        "node": ">=0.12"
-      },
       "funding": {
         "url": "https://github.com/fb55/entities?sponsor=1"
       }
@@ -6314,21 +6311,21 @@
       }
     },
     "node_modules/jsdoc": {
-      "version": "4.0.5",
-      "resolved": "https://registry.npmjs.org/jsdoc/-/jsdoc-4.0.5.tgz",
-      "integrity": "sha512-P4C6MWP9yIlMiK8nwoZvxN84vb6MsnXcHuy7XzVOvQoCizWX5JFCBsWIIWKXBltpoRZXddUOVQmCTOZt9yDj9g==",
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/jsdoc/-/jsdoc-4.0.2.tgz",
+      "integrity": "sha512-e8cIg2z62InH7azBBi3EsSEqrKx+nUtAS5bBcYTSpZFA+vhNPyhv8PTFZ0WsjOPDj04/dOLlm08EDcQJDqaGQg==",
       "dev": true,
       "dependencies": {
         "@babel/parser": "^7.20.15",
         "@jsdoc/salty": "^0.2.1",
-        "@types/markdown-it": "^14.1.1",
+        "@types/markdown-it": "^12.2.3",
         "bluebird": "^3.7.2",
         "catharsis": "^0.9.0",
         "escape-string-regexp": "^2.0.0",
         "js2xmlparser": "^4.0.2",
         "klaw": "^3.0.0",
-        "markdown-it": "^14.1.0",
-        "markdown-it-anchor": "^8.6.7",
+        "markdown-it": "^12.3.2",
+        "markdown-it-anchor": "^8.4.1",
         "marked": "^4.0.10",
         "mkdirp": "^1.0.4",
         "requizzle": "^0.2.3",
@@ -6447,22 +6444,12 @@
       "dev": true
     },
     "node_modules/linkify-it": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/linkify-it/-/linkify-it-5.0.1.tgz",
-      "integrity": "sha512-wVoTjP4Q6R0NW5hiZkVJaFZPWgtXfoGF+6LucL3/FtiNjmcHhYjEr5f1Kqjirc1nBW07J/ZuRFumqr2oqccEWg==",
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/linkify-it/-/linkify-it-3.0.3.tgz",
+      "integrity": "sha512-ynTsyrFSdE5oZ/O9GEf00kPngmOfVwazR5GKDq6EYfhlpFug3J2zybX56a2PRRpc9P+FuSoGNAwjlbDs9jJBPQ==",
       "dev": true,
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/puzrin"
-        },
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/markdown-it"
-        }
-      ],
       "dependencies": {
-        "uc.micro": "^2.0.0"
+        "uc.micro": "^1.0.1"
       }
     },
     "node_modules/locate-path": {
@@ -6550,30 +6537,19 @@
       }
     },
     "node_modules/markdown-it": {
-      "version": "14.2.0",
-      "resolved": "https://registry.npmjs.org/markdown-it/-/markdown-it-14.2.0.tgz",
-      "integrity": "sha512-1TGiQiJVRQ3NPmZH6sx5Cfnmg6GQm9jvC1ch4TK511NjSJvjzKLzn5pPfZRNZkRPZP0HqCioSndqH8v2nRaWVQ==",
+      "version": "12.3.2",
+      "resolved": "https://registry.npmjs.org/markdown-it/-/markdown-it-12.3.2.tgz",
+      "integrity": "sha512-TchMembfxfNVpHkbtriWltGWc+m3xszaRD0CZup7GFFhzIgQqxIfn3eGj1yZpfuflzPvfkt611B2Q/Bsk1YnGg==",
       "dev": true,
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/puzrin"
-        },
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/markdown-it"
-        }
-      ],
       "dependencies": {
         "argparse": "^2.0.1",
-        "entities": "^4.4.0",
-        "linkify-it": "^5.0.1",
-        "mdurl": "^2.0.0",
-        "punycode.js": "^2.3.1",
-        "uc.micro": "^2.1.0"
+        "entities": "~2.1.0",
+        "linkify-it": "^3.0.1",
+        "mdurl": "^1.0.1",
+        "uc.micro": "^1.0.5"
       },
       "bin": {
-        "markdown-it": "bin/markdown-it.mjs"
+        "markdown-it": "bin/markdown-it.js"
       }
     },
     "node_modules/markdown-it-anchor": {
@@ -6609,9 +6585,9 @@
       }
     },
     "node_modules/mdurl": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/mdurl/-/mdurl-2.0.0.tgz",
-      "integrity": "sha512-Lf+9+2r+Tdp5wXDXC4PcIBjTDtq4UKjCPMQhKIuzpJNW0b96kVqSwW0bT7FhRSfmAiFYgP+SCRvdrDozfh0U5w==",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/mdurl/-/mdurl-1.0.1.tgz",
+      "integrity": "sha512-/sKlQJCBYVY9Ers9hqzKou4H6V5UWc/M59TH2dvkt+84itfnq7uFOMLpOiOS4ujvHP4etln18fmIxA5R5fll0g==",
       "dev": true
     },
     "node_modules/merge-stream": {
@@ -7367,9 +7343,10 @@
       "integrity": "sha512-/1WZ8+VQjR6avWOgHeEPd7SDQmFQ1B5mC1eRXsCm5TarlNmx/wCsa5GEaxGm05BORRtyG/Ex/3xq3TuRvq57qg=="
     },
     "node_modules/protobufjs": {
-      "version": "8.6.1",
-      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-8.6.1.tgz",
-      "integrity": "sha512-s4qQPr4pU0W95iYnUInh95skjIg+3aM2sakYsw60QYanU+qWRDY2zQxOAQV6zU7ROJpSNDG9B+VSmk4dqdWWSA==",
+      "version": "8.5.0",
+      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-8.5.0.tgz",
+      "integrity": "sha512-df1jWDPA5VIBNRtuAHjqr09f2qN5D4Vke1wYqOQg1XJ7ZDpA7BD6L7E4tyChgGRLB5hqk2m79Zsy0WHwV9a84A==",
+      "hasInstallScript": true,
       "dependencies": {
         "long": "^5.3.2"
       },
@@ -7378,19 +7355,21 @@
       }
     },
     "node_modules/protobufjs-cli": {
-      "version": "2.5.2",
-      "resolved": "https://registry.npmjs.org/protobufjs-cli/-/protobufjs-cli-2.5.2.tgz",
-      "integrity": "sha512-F+Oswot9soZ2KCWF1LXdT23JFKR5Djs4PZNLBggJHb5fevRYpZ4Oit4nSoyy9+4s4POKAjFXCHr22fTPEJpOqQ==",
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/protobufjs-cli/-/protobufjs-cli-2.5.0.tgz",
+      "integrity": "sha512-NyZm+C4DWP0hEOXR6WaI1GtYBeaZifslexYnlh8FAIZ7OobvmE8ALL8pSELJ39k6IIde/EumTtZ66XIl/kSQMA==",
       "dev": true,
       "dependencies": {
         "chalk": "^4.0.0",
         "escodegen": "^1.13.0",
-        "espree": "^9.6.1",
+        "espree": "^9.0.0",
         "estraverse": "^5.1.0",
-        "glob": "^8.1.0",
-        "jsdoc": "^4.0.5",
+        "glob": "^8.0.0",
+        "jsdoc": "^4.0.0",
         "minimist": "^1.2.8",
-        "tmp": "^0.2.7"
+        "semver": "^7.1.2",
+        "tmp": "^0.2.1",
+        "uglify-js": "^3.7.7"
       },
       "bin": {
         "pbjs": "bin/pbjs",
@@ -7401,7 +7380,7 @@
         "node": ">=12.0.0"
       },
       "peerDependencies": {
-        "protobufjs": "^8.6.1"
+        "protobufjs": "^8.5.0"
       }
     },
     "node_modules/protobufjs-cli/node_modules/brace-expansion": {
@@ -7471,15 +7450,6 @@
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
       "integrity": "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==",
-      "dev": true,
-      "engines": {
-        "node": ">=6"
-      }
-    },
-    "node_modules/punycode.js": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/punycode.js/-/punycode.js-2.3.1.tgz",
-      "integrity": "sha512-uxFIHU0YlHYhDQtV4R9J6a52SLx28BCjT+4ieh7IGbgwVJWO+km431c4yRlREUAsAmt/uMjQUyQHNEPf0M39CA==",
       "dev": true,
       "engines": {
         "node": ">=6"
@@ -8884,9 +8854,9 @@
       }
     },
     "node_modules/uc.micro": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/uc.micro/-/uc.micro-2.1.0.tgz",
-      "integrity": "sha512-ARDJmphmdvUk6Glw7y9DQ2bFkKBHwQHLi2lsaH6PPmz/Ka9sFOBsBluozhDltWmnv9u/cF6Rt87znRTPV+yp/A==",
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/uc.micro/-/uc.micro-1.0.6.tgz",
+      "integrity": "sha512-8Y75pvTYkLJW2hWQHXxoqRgV7qb9B+9vFEtidML+7koHUFapnVJAZ6cKs+Qjz5Aw3aZWHMC6u0wJE3At+nSGwA==",
       "dev": true
     },
     "node_modules/uglify-js": {
@@ -8894,7 +8864,6 @@
       "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.17.4.tgz",
       "integrity": "sha512-T9q82TJI9e/C1TAxYvfb16xO120tMVFZrGA3f9/P4424DNu6ypK103y0GPFVa17yotwSyZW5iYXgjYHkGrJW/g==",
       "dev": true,
-      "optional": true,
       "bin": {
         "uglifyjs": "bin/uglifyjs"
       },
@@ -8922,9 +8891,9 @@
       }
     },
     "node_modules/underscore": {
-      "version": "1.13.8",
-      "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.13.8.tgz",
-      "integrity": "sha512-DXtD3ZtEQzc7M8m4cXotyHR+FAS18C64asBYY5vqZexfYryNNnDc02W4hKg3rdQuqOYas1jkseX0+nZXjTXnvQ==",
+      "version": "1.13.6",
+      "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.13.6.tgz",
+      "integrity": "sha512-+A5Sja4HP1M08MaXya7p5LvjuM7K6q/2EaC0+iovj/wOcMsTzMvDFbasi/oSapiwOlt252IqsKqPjCl7huKS0A==",
       "dev": true
     },
     "node_modules/undici-types": {
@@ -10360,12 +10329,12 @@
       }
     },
     "@jsdoc/salty": {
-      "version": "0.2.12",
-      "resolved": "https://registry.npmjs.org/@jsdoc/salty/-/salty-0.2.12.tgz",
-      "integrity": "sha512-TuB0x50EoAvEX/UEWITd8Mkn3WhiTjSvbTMCLj0BhsQEl5iUzjXdA0bETEVpTk+5TGTLR6QktI9H4hLviVeaAQ==",
+      "version": "0.2.5",
+      "resolved": "https://registry.npmjs.org/@jsdoc/salty/-/salty-0.2.5.tgz",
+      "integrity": "sha512-TfRP53RqunNe2HBobVBJ0VLhK1HbfvBYeTC1ahnN64PWvyYyGebmMiPkuwvD9fpw2ZbkoPb8Q7mwy0aR8Z9rvw==",
       "dev": true,
       "requires": {
-        "lodash": "^4.18.1"
+        "lodash": "^4.17.21"
       }
     },
     "@mapbox/node-pre-gyp": {
@@ -10619,25 +10588,25 @@
       "dev": true
     },
     "@types/linkify-it": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/@types/linkify-it/-/linkify-it-5.0.0.tgz",
-      "integrity": "sha512-sVDA58zAw4eWAffKOaQH5/5j3XeayukzDk+ewSsnv3p4yJEZHCCzMDiZM8e0OUrRvmpGZ85jf4yDHkHsgBNr9Q==",
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@types/linkify-it/-/linkify-it-3.0.2.tgz",
+      "integrity": "sha512-HZQYqbiFVWufzCwexrvh694SOim8z2d+xJl5UNamcvQFejLY/2YUtzXHYi3cHdI7PMlS8ejH2slRAOJQ32aNbA==",
       "dev": true
     },
     "@types/markdown-it": {
-      "version": "14.1.2",
-      "resolved": "https://registry.npmjs.org/@types/markdown-it/-/markdown-it-14.1.2.tgz",
-      "integrity": "sha512-promo4eFwuiW+TfGxhi+0x3czqTYJkG8qB17ZUJiVF10Xm7NLVRSLUsfRTU/6h1e24VvRnXCx+hG7li58lkzog==",
+      "version": "12.2.3",
+      "resolved": "https://registry.npmjs.org/@types/markdown-it/-/markdown-it-12.2.3.tgz",
+      "integrity": "sha512-GKMHFfv3458yYy+v/N8gjufHO6MSZKCOXpZc5GXIWWy8uldwfmPn98vp81gZ5f9SVw8YYBctgfJ22a2d7AOMeQ==",
       "dev": true,
       "requires": {
-        "@types/linkify-it": "^5",
-        "@types/mdurl": "^2"
+        "@types/linkify-it": "*",
+        "@types/mdurl": "*"
       }
     },
     "@types/mdurl": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@types/mdurl/-/mdurl-2.0.0.tgz",
-      "integrity": "sha512-RGdgjQUZba5p6QEFAVx2OGb8rQDL/cPRG7GiedRzMcJ1tYnUANBncjbSB1NRGwbvjcPeikRABz2nshyPk1bhWg==",
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@types/mdurl/-/mdurl-1.0.2.tgz",
+      "integrity": "sha512-eC4U9MlIcu2q0KQmXszyn5Akca/0jrQmwDRgpAMJai7qBWq4amIQhZyNau4VYGtCeALvW1/NtjzJJ567aZxfKA==",
       "dev": true
     },
     "@types/node": {
@@ -11764,9 +11733,9 @@
       "dev": true
     },
     "entities": {
-      "version": "4.5.0",
-      "resolved": "https://registry.npmjs.org/entities/-/entities-4.5.0.tgz",
-      "integrity": "sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-2.1.0.tgz",
+      "integrity": "sha512-hCx1oky9PFrJ611mf0ifBLBRW8lUUVRlFolb5gWRfIELabBlbp9xZvrqZLZAs+NxFnbfQoeGd8wDkygjg7U85w==",
       "dev": true
     },
     "error-ex": {
@@ -13780,21 +13749,21 @@
       }
     },
     "jsdoc": {
-      "version": "4.0.5",
-      "resolved": "https://registry.npmjs.org/jsdoc/-/jsdoc-4.0.5.tgz",
-      "integrity": "sha512-P4C6MWP9yIlMiK8nwoZvxN84vb6MsnXcHuy7XzVOvQoCizWX5JFCBsWIIWKXBltpoRZXddUOVQmCTOZt9yDj9g==",
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/jsdoc/-/jsdoc-4.0.2.tgz",
+      "integrity": "sha512-e8cIg2z62InH7azBBi3EsSEqrKx+nUtAS5bBcYTSpZFA+vhNPyhv8PTFZ0WsjOPDj04/dOLlm08EDcQJDqaGQg==",
       "dev": true,
       "requires": {
         "@babel/parser": "^7.20.15",
         "@jsdoc/salty": "^0.2.1",
-        "@types/markdown-it": "^14.1.1",
+        "@types/markdown-it": "^12.2.3",
         "bluebird": "^3.7.2",
         "catharsis": "^0.9.0",
         "escape-string-regexp": "^2.0.0",
         "js2xmlparser": "^4.0.2",
         "klaw": "^3.0.0",
-        "markdown-it": "^14.1.0",
-        "markdown-it-anchor": "^8.6.7",
+        "markdown-it": "^12.3.2",
+        "markdown-it-anchor": "^8.4.1",
         "marked": "^4.0.10",
         "mkdirp": "^1.0.4",
         "requizzle": "^0.2.3",
@@ -13887,12 +13856,12 @@
       "dev": true
     },
     "linkify-it": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/linkify-it/-/linkify-it-5.0.1.tgz",
-      "integrity": "sha512-wVoTjP4Q6R0NW5hiZkVJaFZPWgtXfoGF+6LucL3/FtiNjmcHhYjEr5f1Kqjirc1nBW07J/ZuRFumqr2oqccEWg==",
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/linkify-it/-/linkify-it-3.0.3.tgz",
+      "integrity": "sha512-ynTsyrFSdE5oZ/O9GEf00kPngmOfVwazR5GKDq6EYfhlpFug3J2zybX56a2PRRpc9P+FuSoGNAwjlbDs9jJBPQ==",
       "dev": true,
       "requires": {
-        "uc.micro": "^2.0.0"
+        "uc.micro": "^1.0.1"
       }
     },
     "locate-path": {
@@ -13967,17 +13936,16 @@
       }
     },
     "markdown-it": {
-      "version": "14.2.0",
-      "resolved": "https://registry.npmjs.org/markdown-it/-/markdown-it-14.2.0.tgz",
-      "integrity": "sha512-1TGiQiJVRQ3NPmZH6sx5Cfnmg6GQm9jvC1ch4TK511NjSJvjzKLzn5pPfZRNZkRPZP0HqCioSndqH8v2nRaWVQ==",
+      "version": "12.3.2",
+      "resolved": "https://registry.npmjs.org/markdown-it/-/markdown-it-12.3.2.tgz",
+      "integrity": "sha512-TchMembfxfNVpHkbtriWltGWc+m3xszaRD0CZup7GFFhzIgQqxIfn3eGj1yZpfuflzPvfkt611B2Q/Bsk1YnGg==",
       "dev": true,
       "requires": {
         "argparse": "^2.0.1",
-        "entities": "^4.4.0",
-        "linkify-it": "^5.0.1",
-        "mdurl": "^2.0.0",
-        "punycode.js": "^2.3.1",
-        "uc.micro": "^2.1.0"
+        "entities": "~2.1.0",
+        "linkify-it": "^3.0.1",
+        "mdurl": "^1.0.1",
+        "uc.micro": "^1.0.5"
       }
     },
     "markdown-it-anchor": {
@@ -14000,9 +13968,9 @@
       "dev": true
     },
     "mdurl": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/mdurl/-/mdurl-2.0.0.tgz",
-      "integrity": "sha512-Lf+9+2r+Tdp5wXDXC4PcIBjTDtq4UKjCPMQhKIuzpJNW0b96kVqSwW0bT7FhRSfmAiFYgP+SCRvdrDozfh0U5w==",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/mdurl/-/mdurl-1.0.1.tgz",
+      "integrity": "sha512-/sKlQJCBYVY9Ers9hqzKou4H6V5UWc/M59TH2dvkt+84itfnq7uFOMLpOiOS4ujvHP4etln18fmIxA5R5fll0g==",
       "dev": true
     },
     "merge-stream": {
@@ -14537,27 +14505,29 @@
       "integrity": "sha512-/1WZ8+VQjR6avWOgHeEPd7SDQmFQ1B5mC1eRXsCm5TarlNmx/wCsa5GEaxGm05BORRtyG/Ex/3xq3TuRvq57qg=="
     },
     "protobufjs": {
-      "version": "8.6.1",
-      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-8.6.1.tgz",
-      "integrity": "sha512-s4qQPr4pU0W95iYnUInh95skjIg+3aM2sakYsw60QYanU+qWRDY2zQxOAQV6zU7ROJpSNDG9B+VSmk4dqdWWSA==",
+      "version": "8.5.0",
+      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-8.5.0.tgz",
+      "integrity": "sha512-df1jWDPA5VIBNRtuAHjqr09f2qN5D4Vke1wYqOQg1XJ7ZDpA7BD6L7E4tyChgGRLB5hqk2m79Zsy0WHwV9a84A==",
       "requires": {
         "long": "^5.3.2"
       }
     },
     "protobufjs-cli": {
-      "version": "2.5.2",
-      "resolved": "https://registry.npmjs.org/protobufjs-cli/-/protobufjs-cli-2.5.2.tgz",
-      "integrity": "sha512-F+Oswot9soZ2KCWF1LXdT23JFKR5Djs4PZNLBggJHb5fevRYpZ4Oit4nSoyy9+4s4POKAjFXCHr22fTPEJpOqQ==",
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/protobufjs-cli/-/protobufjs-cli-2.5.0.tgz",
+      "integrity": "sha512-NyZm+C4DWP0hEOXR6WaI1GtYBeaZifslexYnlh8FAIZ7OobvmE8ALL8pSELJ39k6IIde/EumTtZ66XIl/kSQMA==",
       "dev": true,
       "requires": {
         "chalk": "^4.0.0",
         "escodegen": "^1.13.0",
-        "espree": "^9.6.1",
+        "espree": "^9.0.0",
         "estraverse": "^5.1.0",
-        "glob": "^8.1.0",
-        "jsdoc": "^4.0.5",
+        "glob": "^8.0.0",
+        "jsdoc": "^4.0.0",
         "minimist": "^1.2.8",
-        "tmp": "^0.2.7"
+        "semver": "^7.1.2",
+        "tmp": "^0.2.1",
+        "uglify-js": "^3.7.7"
       },
       "dependencies": {
         "brace-expansion": {
@@ -14613,12 +14583,6 @@
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
       "integrity": "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==",
-      "dev": true
-    },
-    "punycode.js": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/punycode.js/-/punycode.js-2.3.1.tgz",
-      "integrity": "sha512-uxFIHU0YlHYhDQtV4R9J6a52SLx28BCjT+4ieh7IGbgwVJWO+km431c4yRlREUAsAmt/uMjQUyQHNEPf0M39CA==",
       "dev": true
     },
     "pure-rand": {
@@ -15572,17 +15536,16 @@
       "dev": true
     },
     "uc.micro": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/uc.micro/-/uc.micro-2.1.0.tgz",
-      "integrity": "sha512-ARDJmphmdvUk6Glw7y9DQ2bFkKBHwQHLi2lsaH6PPmz/Ka9sFOBsBluozhDltWmnv9u/cF6Rt87znRTPV+yp/A==",
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/uc.micro/-/uc.micro-1.0.6.tgz",
+      "integrity": "sha512-8Y75pvTYkLJW2hWQHXxoqRgV7qb9B+9vFEtidML+7koHUFapnVJAZ6cKs+Qjz5Aw3aZWHMC6u0wJE3At+nSGwA==",
       "dev": true
     },
     "uglify-js": {
       "version": "3.17.4",
       "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.17.4.tgz",
       "integrity": "sha512-T9q82TJI9e/C1TAxYvfb16xO120tMVFZrGA3f9/P4424DNu6ypK103y0GPFVa17yotwSyZW5iYXgjYHkGrJW/g==",
-      "dev": true,
-      "optional": true
+      "dev": true
     },
     "unbox-primitive": {
       "version": "1.1.0",
@@ -15597,9 +15560,9 @@
       }
     },
     "underscore": {
-      "version": "1.13.8",
-      "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.13.8.tgz",
-      "integrity": "sha512-DXtD3ZtEQzc7M8m4cXotyHR+FAS18C64asBYY5vqZexfYryNNnDc02W4hKg3rdQuqOYas1jkseX0+nZXjTXnvQ==",
+      "version": "1.13.6",
+      "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.13.6.tgz",
+      "integrity": "sha512-+A5Sja4HP1M08MaXya7p5LvjuM7K6q/2EaC0+iovj/wOcMsTzMvDFbasi/oSapiwOlt252IqsKqPjCl7huKS0A==",
       "dev": true
     },
     "undici-types": {

--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
     "eslint-plugin-prettier": "^4.0.0",
     "jest": "^30.4.2",
     "prettier": "^2.8.8",
-    "protobufjs-cli": "^2.5.2",
+    "protobufjs-cli": "^2.5.0",
     "quicktype": "^23.2.6",
     "ts-jest": "^29.4.11",
     "typescript": "^5.9.3"
@@ -57,7 +57,7 @@
     "date-fns": "^4.4.0",
     "date-fns-tz": "^3.2.0",
     "pino": "^8.16.2",
-    "protobufjs": "^8.6.1",
+    "protobufjs": "^8.5.0",
     "pulsar-client": "^1.17.0"
   },
   "jest": {

--- a/src/protobuf/gtfsRealtime.d.ts
+++ b/src/protobuf/gtfsRealtime.d.ts
@@ -1,37 +1,41 @@
 import * as $protobuf from "protobufjs";
 import Long = require("long");
+
 /** Namespace transit_realtime. */
 export namespace transit_realtime {
-  /** Properties of a FeedMessage. */
-  interface IFeedMessage {
-    /** FeedMessage header */
-    header: transit_realtime.IFeedHeader;
-
-    /** FeedMessage entity */
-    entity?: transit_realtime.IFeedEntity[] | null;
-  }
+  /**
+   * Properties of a FeedMessage.
+   * @deprecated Use transit_realtime.FeedMessage.$Properties instead.
+   */
+  interface IFeedMessage extends transit_realtime.FeedMessage.$Properties {}
 
   /** Represents a FeedMessage. */
-  class FeedMessage implements IFeedMessage {
+  class FeedMessage {
     /**
      * Constructs a new FeedMessage.
      * @param [properties] Properties to set
      */
-    constructor(properties?: transit_realtime.IFeedMessage);
+    constructor(properties?: transit_realtime.FeedMessage.$Properties);
+
+    /** Unknown fields preserved while decoding */
+    $unknowns?: Uint8Array[];
 
     /** FeedMessage header. */
-    public header: transit_realtime.IFeedHeader;
+    header: transit_realtime.FeedHeader.$Properties;
 
     /** FeedMessage entity. */
-    public entity: transit_realtime.IFeedEntity[];
+    entity: transit_realtime.FeedEntity.$Properties[];
 
     /**
      * Creates a new FeedMessage instance using the specified properties.
      * @param [properties] Properties to set
      * @returns FeedMessage instance
      */
-    public static create(
-      properties?: transit_realtime.IFeedMessage
+    static create(
+      properties: transit_realtime.FeedMessage.$Shape
+    ): transit_realtime.FeedMessage & transit_realtime.FeedMessage.$Shape;
+    static create(
+      properties?: transit_realtime.FeedMessage.$Properties
     ): transit_realtime.FeedMessage;
 
     /**
@@ -40,8 +44,8 @@ export namespace transit_realtime {
      * @param [writer] Writer to encode to
      * @returns Writer
      */
-    public static encode(
-      message: transit_realtime.IFeedMessage,
+    static encode(
+      message: transit_realtime.FeedMessage.$Properties,
       writer?: $protobuf.Writer
     ): $protobuf.Writer;
 
@@ -51,8 +55,8 @@ export namespace transit_realtime {
      * @param [writer] Writer to encode to
      * @returns Writer
      */
-    public static encodeDelimited(
-      message: transit_realtime.IFeedMessage,
+    static encodeDelimited(
+      message: transit_realtime.FeedMessage.$Properties,
       writer?: $protobuf.Writer
     ): $protobuf.Writer;
 
@@ -60,39 +64,39 @@ export namespace transit_realtime {
      * Decodes a FeedMessage message from the specified reader or buffer.
      * @param reader Reader or buffer to decode from
      * @param [length] Message length if known beforehand
-     * @returns FeedMessage
+     * @returns {transit_realtime.FeedMessage & transit_realtime.FeedMessage.$Shape} FeedMessage
      * @throws {Error} If the payload is not a reader or valid buffer
      * @throws {$protobuf.util.ProtocolError} If required fields are missing
      */
-    public static decode(
+    static decode(
       reader: $protobuf.Reader | Uint8Array,
       length?: number
-    ): transit_realtime.FeedMessage;
+    ): transit_realtime.FeedMessage & transit_realtime.FeedMessage.$Shape;
 
     /**
      * Decodes a FeedMessage message from the specified reader or buffer, length delimited.
      * @param reader Reader or buffer to decode from
-     * @returns FeedMessage
+     * @returns {transit_realtime.FeedMessage & transit_realtime.FeedMessage.$Shape} FeedMessage
      * @throws {Error} If the payload is not a reader or valid buffer
      * @throws {$protobuf.util.ProtocolError} If required fields are missing
      */
-    public static decodeDelimited(
+    static decodeDelimited(
       reader: $protobuf.Reader | Uint8Array
-    ): transit_realtime.FeedMessage;
+    ): transit_realtime.FeedMessage & transit_realtime.FeedMessage.$Shape;
 
     /**
      * Verifies a FeedMessage message.
      * @param message Plain object to verify
      * @returns `null` if valid, otherwise the reason why it is not
      */
-    public static verify(message: { [k: string]: any }): string | null;
+    static verify(message: { [k: string]: any }): string | null;
 
     /**
      * Creates a FeedMessage message from a plain object. Also converts values to their respective internal types.
      * @param object Plain object
      * @returns FeedMessage
      */
-    public static fromObject(object: {
+    static fromObject(object: {
       [k: string]: any;
     }): transit_realtime.FeedMessage;
 
@@ -102,7 +106,7 @@ export namespace transit_realtime {
      * @param [options] Conversion options
      * @returns Plain object
      */
-    public static toObject(
+    static toObject(
       message: transit_realtime.FeedMessage,
       options?: $protobuf.IConversionOptions
     ): { [k: string]: any };
@@ -111,52 +115,69 @@ export namespace transit_realtime {
      * Converts this FeedMessage to JSON.
      * @returns JSON object
      */
-    public toJSON(): { [k: string]: any };
+    toJSON(): { [k: string]: any };
 
     /**
-     * Gets the default type url for FeedMessage
-     * @param [typeUrlPrefix] your custom typeUrlPrefix(default "type.googleapis.com")
-     * @returns The default type url
+     * Gets the type url for FeedMessage
+     * @param [prefix] Custom type url prefix, defaults to `"type.googleapis.com"`
+     * @returns The type url
      */
-    public static getTypeUrl(typeUrlPrefix?: string): string;
+    static getTypeUrl(prefix?: string): string;
   }
 
-  /** Properties of a FeedHeader. */
-  interface IFeedHeader {
-    /** FeedHeader gtfsRealtimeVersion */
-    gtfsRealtimeVersion: string;
+  namespace FeedMessage {
+    /** Properties of a FeedMessage. */
+    interface $Properties {
+      /** FeedMessage header */
+      header: transit_realtime.FeedHeader.$Properties;
 
-    /** FeedHeader incrementality */
-    incrementality?: transit_realtime.FeedHeader.Incrementality | null;
+      /** FeedMessage entity */
+      entity?: transit_realtime.FeedEntity.$Properties[] | null;
 
-    /** FeedHeader timestamp */
-    timestamp?: number | Long | null;
+      /** Unknown fields preserved while decoding */
+      $unknowns?: Uint8Array[];
+    }
+
+    /** Shape of a FeedMessage. */
+    type $Shape = transit_realtime.FeedMessage.$Properties;
   }
+
+  /**
+   * Properties of a FeedHeader.
+   * @deprecated Use transit_realtime.FeedHeader.$Properties instead.
+   */
+  interface IFeedHeader extends transit_realtime.FeedHeader.$Properties {}
 
   /** Represents a FeedHeader. */
-  class FeedHeader implements IFeedHeader {
+  class FeedHeader {
     /**
      * Constructs a new FeedHeader.
      * @param [properties] Properties to set
      */
-    constructor(properties?: transit_realtime.IFeedHeader);
+    constructor(properties?: transit_realtime.FeedHeader.$Properties);
+
+    /** Unknown fields preserved while decoding */
+    $unknowns?: Uint8Array[];
 
     /** FeedHeader gtfsRealtimeVersion. */
-    public gtfsRealtimeVersion: string;
+    gtfsRealtimeVersion: string;
 
     /** FeedHeader incrementality. */
-    public incrementality: transit_realtime.FeedHeader.Incrementality;
+    incrementality: transit_realtime.FeedHeader.Incrementality;
 
     /** FeedHeader timestamp. */
-    public timestamp: number | Long;
+    timestamp: number | Long;
 
     /**
      * Creates a new FeedHeader instance using the specified properties.
      * @param [properties] Properties to set
      * @returns FeedHeader instance
      */
-    public static create(
-      properties?: transit_realtime.IFeedHeader
+    static create(
+      properties: transit_realtime.FeedHeader.$Shape
+    ): transit_realtime.FeedHeader & transit_realtime.FeedHeader.$Shape;
+    static create(
+      properties?: transit_realtime.FeedHeader.$Properties
     ): transit_realtime.FeedHeader;
 
     /**
@@ -165,8 +186,8 @@ export namespace transit_realtime {
      * @param [writer] Writer to encode to
      * @returns Writer
      */
-    public static encode(
-      message: transit_realtime.IFeedHeader,
+    static encode(
+      message: transit_realtime.FeedHeader.$Properties,
       writer?: $protobuf.Writer
     ): $protobuf.Writer;
 
@@ -176,8 +197,8 @@ export namespace transit_realtime {
      * @param [writer] Writer to encode to
      * @returns Writer
      */
-    public static encodeDelimited(
-      message: transit_realtime.IFeedHeader,
+    static encodeDelimited(
+      message: transit_realtime.FeedHeader.$Properties,
       writer?: $protobuf.Writer
     ): $protobuf.Writer;
 
@@ -185,39 +206,39 @@ export namespace transit_realtime {
      * Decodes a FeedHeader message from the specified reader or buffer.
      * @param reader Reader or buffer to decode from
      * @param [length] Message length if known beforehand
-     * @returns FeedHeader
+     * @returns {transit_realtime.FeedHeader & transit_realtime.FeedHeader.$Shape} FeedHeader
      * @throws {Error} If the payload is not a reader or valid buffer
      * @throws {$protobuf.util.ProtocolError} If required fields are missing
      */
-    public static decode(
+    static decode(
       reader: $protobuf.Reader | Uint8Array,
       length?: number
-    ): transit_realtime.FeedHeader;
+    ): transit_realtime.FeedHeader & transit_realtime.FeedHeader.$Shape;
 
     /**
      * Decodes a FeedHeader message from the specified reader or buffer, length delimited.
      * @param reader Reader or buffer to decode from
-     * @returns FeedHeader
+     * @returns {transit_realtime.FeedHeader & transit_realtime.FeedHeader.$Shape} FeedHeader
      * @throws {Error} If the payload is not a reader or valid buffer
      * @throws {$protobuf.util.ProtocolError} If required fields are missing
      */
-    public static decodeDelimited(
+    static decodeDelimited(
       reader: $protobuf.Reader | Uint8Array
-    ): transit_realtime.FeedHeader;
+    ): transit_realtime.FeedHeader & transit_realtime.FeedHeader.$Shape;
 
     /**
      * Verifies a FeedHeader message.
      * @param message Plain object to verify
      * @returns `null` if valid, otherwise the reason why it is not
      */
-    public static verify(message: { [k: string]: any }): string | null;
+    static verify(message: { [k: string]: any }): string | null;
 
     /**
      * Creates a FeedHeader message from a plain object. Also converts values to their respective internal types.
      * @param object Plain object
      * @returns FeedHeader
      */
-    public static fromObject(object: {
+    static fromObject(object: {
       [k: string]: any;
     }): transit_realtime.FeedHeader;
 
@@ -227,7 +248,7 @@ export namespace transit_realtime {
      * @param [options] Conversion options
      * @returns Plain object
      */
-    public static toObject(
+    static toObject(
       message: transit_realtime.FeedHeader,
       options?: $protobuf.IConversionOptions
     ): { [k: string]: any };
@@ -236,72 +257,87 @@ export namespace transit_realtime {
      * Converts this FeedHeader to JSON.
      * @returns JSON object
      */
-    public toJSON(): { [k: string]: any };
+    toJSON(): { [k: string]: any };
 
     /**
-     * Gets the default type url for FeedHeader
-     * @param [typeUrlPrefix] your custom typeUrlPrefix(default "type.googleapis.com")
-     * @returns The default type url
+     * Gets the type url for FeedHeader
+     * @param [prefix] Custom type url prefix, defaults to `"type.googleapis.com"`
+     * @returns The type url
      */
-    public static getTypeUrl(typeUrlPrefix?: string): string;
+    static getTypeUrl(prefix?: string): string;
   }
 
   namespace FeedHeader {
+    /** Properties of a FeedHeader. */
+    interface $Properties {
+      /** FeedHeader gtfsRealtimeVersion */
+      gtfsRealtimeVersion: string;
+
+      /** FeedHeader incrementality */
+      incrementality?: transit_realtime.FeedHeader.Incrementality | null;
+
+      /** FeedHeader timestamp */
+      timestamp?: number | Long | null;
+
+      /** Unknown fields preserved while decoding */
+      $unknowns?: Uint8Array[];
+    }
+
+    /** Shape of a FeedHeader. */
+    type $Shape = transit_realtime.FeedHeader.$Properties;
+
     /** Incrementality enum. */
     enum Incrementality {
+      /** FULL_DATASET value */
       FULL_DATASET = 0,
+
+      /** DIFFERENTIAL value */
       DIFFERENTIAL = 1,
     }
   }
 
-  /** Properties of a FeedEntity. */
-  interface IFeedEntity {
-    /** FeedEntity id */
-    id: string;
-
-    /** FeedEntity isDeleted */
-    isDeleted?: boolean | null;
-
-    /** FeedEntity tripUpdate */
-    tripUpdate?: transit_realtime.ITripUpdate | null;
-
-    /** FeedEntity vehicle */
-    vehicle?: transit_realtime.IVehiclePosition | null;
-
-    /** FeedEntity alert */
-    alert?: transit_realtime.IAlert | null;
-  }
+  /**
+   * Properties of a FeedEntity.
+   * @deprecated Use transit_realtime.FeedEntity.$Properties instead.
+   */
+  interface IFeedEntity extends transit_realtime.FeedEntity.$Properties {}
 
   /** Represents a FeedEntity. */
-  class FeedEntity implements IFeedEntity {
+  class FeedEntity {
     /**
      * Constructs a new FeedEntity.
      * @param [properties] Properties to set
      */
-    constructor(properties?: transit_realtime.IFeedEntity);
+    constructor(properties?: transit_realtime.FeedEntity.$Properties);
+
+    /** Unknown fields preserved while decoding */
+    $unknowns?: Uint8Array[];
 
     /** FeedEntity id. */
-    public id: string;
+    id: string;
 
     /** FeedEntity isDeleted. */
-    public isDeleted: boolean;
+    isDeleted: boolean;
 
     /** FeedEntity tripUpdate. */
-    public tripUpdate?: transit_realtime.ITripUpdate | null;
+    tripUpdate?: transit_realtime.TripUpdate.$Properties | null;
 
     /** FeedEntity vehicle. */
-    public vehicle?: transit_realtime.IVehiclePosition | null;
+    vehicle?: transit_realtime.VehiclePosition.$Properties | null;
 
     /** FeedEntity alert. */
-    public alert?: transit_realtime.IAlert | null;
+    alert?: transit_realtime.Alert.$Properties | null;
 
     /**
      * Creates a new FeedEntity instance using the specified properties.
      * @param [properties] Properties to set
      * @returns FeedEntity instance
      */
-    public static create(
-      properties?: transit_realtime.IFeedEntity
+    static create(
+      properties: transit_realtime.FeedEntity.$Shape
+    ): transit_realtime.FeedEntity & transit_realtime.FeedEntity.$Shape;
+    static create(
+      properties?: transit_realtime.FeedEntity.$Properties
     ): transit_realtime.FeedEntity;
 
     /**
@@ -310,8 +346,8 @@ export namespace transit_realtime {
      * @param [writer] Writer to encode to
      * @returns Writer
      */
-    public static encode(
-      message: transit_realtime.IFeedEntity,
+    static encode(
+      message: transit_realtime.FeedEntity.$Properties,
       writer?: $protobuf.Writer
     ): $protobuf.Writer;
 
@@ -321,8 +357,8 @@ export namespace transit_realtime {
      * @param [writer] Writer to encode to
      * @returns Writer
      */
-    public static encodeDelimited(
-      message: transit_realtime.IFeedEntity,
+    static encodeDelimited(
+      message: transit_realtime.FeedEntity.$Properties,
       writer?: $protobuf.Writer
     ): $protobuf.Writer;
 
@@ -330,39 +366,39 @@ export namespace transit_realtime {
      * Decodes a FeedEntity message from the specified reader or buffer.
      * @param reader Reader or buffer to decode from
      * @param [length] Message length if known beforehand
-     * @returns FeedEntity
+     * @returns {transit_realtime.FeedEntity & transit_realtime.FeedEntity.$Shape} FeedEntity
      * @throws {Error} If the payload is not a reader or valid buffer
      * @throws {$protobuf.util.ProtocolError} If required fields are missing
      */
-    public static decode(
+    static decode(
       reader: $protobuf.Reader | Uint8Array,
       length?: number
-    ): transit_realtime.FeedEntity;
+    ): transit_realtime.FeedEntity & transit_realtime.FeedEntity.$Shape;
 
     /**
      * Decodes a FeedEntity message from the specified reader or buffer, length delimited.
      * @param reader Reader or buffer to decode from
-     * @returns FeedEntity
+     * @returns {transit_realtime.FeedEntity & transit_realtime.FeedEntity.$Shape} FeedEntity
      * @throws {Error} If the payload is not a reader or valid buffer
      * @throws {$protobuf.util.ProtocolError} If required fields are missing
      */
-    public static decodeDelimited(
+    static decodeDelimited(
       reader: $protobuf.Reader | Uint8Array
-    ): transit_realtime.FeedEntity;
+    ): transit_realtime.FeedEntity & transit_realtime.FeedEntity.$Shape;
 
     /**
      * Verifies a FeedEntity message.
      * @param message Plain object to verify
      * @returns `null` if valid, otherwise the reason why it is not
      */
-    public static verify(message: { [k: string]: any }): string | null;
+    static verify(message: { [k: string]: any }): string | null;
 
     /**
      * Creates a FeedEntity message from a plain object. Also converts values to their respective internal types.
      * @param object Plain object
      * @returns FeedEntity
      */
-    public static fromObject(object: {
+    static fromObject(object: {
       [k: string]: any;
     }): transit_realtime.FeedEntity;
 
@@ -372,7 +408,7 @@ export namespace transit_realtime {
      * @param [options] Conversion options
      * @returns Plain object
      */
-    public static toObject(
+    static toObject(
       message: transit_realtime.FeedEntity,
       options?: $protobuf.IConversionOptions
     ): { [k: string]: any };
@@ -381,64 +417,84 @@ export namespace transit_realtime {
      * Converts this FeedEntity to JSON.
      * @returns JSON object
      */
-    public toJSON(): { [k: string]: any };
+    toJSON(): { [k: string]: any };
 
     /**
-     * Gets the default type url for FeedEntity
-     * @param [typeUrlPrefix] your custom typeUrlPrefix(default "type.googleapis.com")
-     * @returns The default type url
+     * Gets the type url for FeedEntity
+     * @param [prefix] Custom type url prefix, defaults to `"type.googleapis.com"`
+     * @returns The type url
      */
-    public static getTypeUrl(typeUrlPrefix?: string): string;
+    static getTypeUrl(prefix?: string): string;
   }
 
-  /** Properties of a TripUpdate. */
-  interface ITripUpdate {
-    /** TripUpdate trip */
-    trip: transit_realtime.ITripDescriptor;
+  namespace FeedEntity {
+    /** Properties of a FeedEntity. */
+    interface $Properties {
+      /** FeedEntity id */
+      id: string;
 
-    /** TripUpdate vehicle */
-    vehicle?: transit_realtime.IVehicleDescriptor | null;
+      /** FeedEntity isDeleted */
+      isDeleted?: boolean | null;
 
-    /** TripUpdate stopTimeUpdate */
-    stopTimeUpdate?: transit_realtime.TripUpdate.IStopTimeUpdate[] | null;
+      /** FeedEntity tripUpdate */
+      tripUpdate?: transit_realtime.TripUpdate.$Properties | null;
 
-    /** TripUpdate timestamp */
-    timestamp?: number | Long | null;
+      /** FeedEntity vehicle */
+      vehicle?: transit_realtime.VehiclePosition.$Properties | null;
 
-    /** TripUpdate delay */
-    delay?: number | null;
+      /** FeedEntity alert */
+      alert?: transit_realtime.Alert.$Properties | null;
+
+      /** Unknown fields preserved while decoding */
+      $unknowns?: Uint8Array[];
+    }
+
+    /** Shape of a FeedEntity. */
+    type $Shape = transit_realtime.FeedEntity.$Properties;
   }
+
+  /**
+   * Properties of a TripUpdate.
+   * @deprecated Use transit_realtime.TripUpdate.$Properties instead.
+   */
+  interface ITripUpdate extends transit_realtime.TripUpdate.$Properties {}
 
   /** Represents a TripUpdate. */
-  class TripUpdate implements ITripUpdate {
+  class TripUpdate {
     /**
      * Constructs a new TripUpdate.
      * @param [properties] Properties to set
      */
-    constructor(properties?: transit_realtime.ITripUpdate);
+    constructor(properties?: transit_realtime.TripUpdate.$Properties);
+
+    /** Unknown fields preserved while decoding */
+    $unknowns?: Uint8Array[];
 
     /** TripUpdate trip. */
-    public trip: transit_realtime.ITripDescriptor;
+    trip: transit_realtime.TripDescriptor.$Properties;
 
     /** TripUpdate vehicle. */
-    public vehicle?: transit_realtime.IVehicleDescriptor | null;
+    vehicle?: transit_realtime.VehicleDescriptor.$Properties | null;
 
     /** TripUpdate stopTimeUpdate. */
-    public stopTimeUpdate: transit_realtime.TripUpdate.IStopTimeUpdate[];
+    stopTimeUpdate: transit_realtime.TripUpdate.StopTimeUpdate.$Properties[];
 
     /** TripUpdate timestamp. */
-    public timestamp: number | Long;
+    timestamp: number | Long;
 
     /** TripUpdate delay. */
-    public delay: number;
+    delay: number;
 
     /**
      * Creates a new TripUpdate instance using the specified properties.
      * @param [properties] Properties to set
      * @returns TripUpdate instance
      */
-    public static create(
-      properties?: transit_realtime.ITripUpdate
+    static create(
+      properties: transit_realtime.TripUpdate.$Shape
+    ): transit_realtime.TripUpdate & transit_realtime.TripUpdate.$Shape;
+    static create(
+      properties?: transit_realtime.TripUpdate.$Properties
     ): transit_realtime.TripUpdate;
 
     /**
@@ -447,8 +503,8 @@ export namespace transit_realtime {
      * @param [writer] Writer to encode to
      * @returns Writer
      */
-    public static encode(
-      message: transit_realtime.ITripUpdate,
+    static encode(
+      message: transit_realtime.TripUpdate.$Properties,
       writer?: $protobuf.Writer
     ): $protobuf.Writer;
 
@@ -458,8 +514,8 @@ export namespace transit_realtime {
      * @param [writer] Writer to encode to
      * @returns Writer
      */
-    public static encodeDelimited(
-      message: transit_realtime.ITripUpdate,
+    static encodeDelimited(
+      message: transit_realtime.TripUpdate.$Properties,
       writer?: $protobuf.Writer
     ): $protobuf.Writer;
 
@@ -467,39 +523,39 @@ export namespace transit_realtime {
      * Decodes a TripUpdate message from the specified reader or buffer.
      * @param reader Reader or buffer to decode from
      * @param [length] Message length if known beforehand
-     * @returns TripUpdate
+     * @returns {transit_realtime.TripUpdate & transit_realtime.TripUpdate.$Shape} TripUpdate
      * @throws {Error} If the payload is not a reader or valid buffer
      * @throws {$protobuf.util.ProtocolError} If required fields are missing
      */
-    public static decode(
+    static decode(
       reader: $protobuf.Reader | Uint8Array,
       length?: number
-    ): transit_realtime.TripUpdate;
+    ): transit_realtime.TripUpdate & transit_realtime.TripUpdate.$Shape;
 
     /**
      * Decodes a TripUpdate message from the specified reader or buffer, length delimited.
      * @param reader Reader or buffer to decode from
-     * @returns TripUpdate
+     * @returns {transit_realtime.TripUpdate & transit_realtime.TripUpdate.$Shape} TripUpdate
      * @throws {Error} If the payload is not a reader or valid buffer
      * @throws {$protobuf.util.ProtocolError} If required fields are missing
      */
-    public static decodeDelimited(
+    static decodeDelimited(
       reader: $protobuf.Reader | Uint8Array
-    ): transit_realtime.TripUpdate;
+    ): transit_realtime.TripUpdate & transit_realtime.TripUpdate.$Shape;
 
     /**
      * Verifies a TripUpdate message.
      * @param message Plain object to verify
      * @returns `null` if valid, otherwise the reason why it is not
      */
-    public static verify(message: { [k: string]: any }): string | null;
+    static verify(message: { [k: string]: any }): string | null;
 
     /**
      * Creates a TripUpdate message from a plain object. Also converts values to their respective internal types.
      * @param object Plain object
      * @returns TripUpdate
      */
-    public static fromObject(object: {
+    static fromObject(object: {
       [k: string]: any;
     }): transit_realtime.TripUpdate;
 
@@ -509,7 +565,7 @@ export namespace transit_realtime {
      * @param [options] Conversion options
      * @returns Plain object
      */
-    public static toObject(
+    static toObject(
       message: transit_realtime.TripUpdate,
       options?: $protobuf.IConversionOptions
     ): { [k: string]: any };
@@ -518,53 +574,83 @@ export namespace transit_realtime {
      * Converts this TripUpdate to JSON.
      * @returns JSON object
      */
-    public toJSON(): { [k: string]: any };
+    toJSON(): { [k: string]: any };
 
     /**
-     * Gets the default type url for TripUpdate
-     * @param [typeUrlPrefix] your custom typeUrlPrefix(default "type.googleapis.com")
-     * @returns The default type url
+     * Gets the type url for TripUpdate
+     * @param [prefix] Custom type url prefix, defaults to `"type.googleapis.com"`
+     * @returns The type url
      */
-    public static getTypeUrl(typeUrlPrefix?: string): string;
+    static getTypeUrl(prefix?: string): string;
   }
 
   namespace TripUpdate {
-    /** Properties of a StopTimeEvent. */
-    interface IStopTimeEvent {
-      /** StopTimeEvent delay */
+    /** Properties of a TripUpdate. */
+    interface $Properties {
+      /** TripUpdate trip */
+      trip: transit_realtime.TripDescriptor.$Properties;
+
+      /** TripUpdate vehicle */
+      vehicle?: transit_realtime.VehicleDescriptor.$Properties | null;
+
+      /** TripUpdate stopTimeUpdate */
+      stopTimeUpdate?:
+        | transit_realtime.TripUpdate.StopTimeUpdate.$Properties[]
+        | null;
+
+      /** TripUpdate timestamp */
+      timestamp?: number | Long | null;
+
+      /** TripUpdate delay */
       delay?: number | null;
 
-      /** StopTimeEvent time */
-      time?: number | Long | null;
-
-      /** StopTimeEvent uncertainty */
-      uncertainty?: number | null;
+      /** Unknown fields preserved while decoding */
+      $unknowns?: Uint8Array[];
     }
 
+    /** Shape of a TripUpdate. */
+    type $Shape = transit_realtime.TripUpdate.$Properties;
+
+    /**
+     * Properties of a StopTimeEvent.
+     * @deprecated Use transit_realtime.TripUpdate.StopTimeEvent.$Properties instead.
+     */
+    interface IStopTimeEvent
+      extends transit_realtime.TripUpdate.StopTimeEvent.$Properties {}
+
     /** Represents a StopTimeEvent. */
-    class StopTimeEvent implements IStopTimeEvent {
+    class StopTimeEvent {
       /**
        * Constructs a new StopTimeEvent.
        * @param [properties] Properties to set
        */
-      constructor(properties?: transit_realtime.TripUpdate.IStopTimeEvent);
+      constructor(
+        properties?: transit_realtime.TripUpdate.StopTimeEvent.$Properties
+      );
+
+      /** Unknown fields preserved while decoding */
+      $unknowns?: Uint8Array[];
 
       /** StopTimeEvent delay. */
-      public delay: number;
+      delay: number;
 
       /** StopTimeEvent time. */
-      public time: number | Long;
+      time: number | Long;
 
       /** StopTimeEvent uncertainty. */
-      public uncertainty: number;
+      uncertainty: number;
 
       /**
        * Creates a new StopTimeEvent instance using the specified properties.
        * @param [properties] Properties to set
        * @returns StopTimeEvent instance
        */
-      public static create(
-        properties?: transit_realtime.TripUpdate.IStopTimeEvent
+      static create(
+        properties: transit_realtime.TripUpdate.StopTimeEvent.$Shape
+      ): transit_realtime.TripUpdate.StopTimeEvent &
+        transit_realtime.TripUpdate.StopTimeEvent.$Shape;
+      static create(
+        properties?: transit_realtime.TripUpdate.StopTimeEvent.$Properties
       ): transit_realtime.TripUpdate.StopTimeEvent;
 
       /**
@@ -573,8 +659,8 @@ export namespace transit_realtime {
        * @param [writer] Writer to encode to
        * @returns Writer
        */
-      public static encode(
-        message: transit_realtime.TripUpdate.IStopTimeEvent,
+      static encode(
+        message: transit_realtime.TripUpdate.StopTimeEvent.$Properties,
         writer?: $protobuf.Writer
       ): $protobuf.Writer;
 
@@ -584,8 +670,8 @@ export namespace transit_realtime {
        * @param [writer] Writer to encode to
        * @returns Writer
        */
-      public static encodeDelimited(
-        message: transit_realtime.TripUpdate.IStopTimeEvent,
+      static encodeDelimited(
+        message: transit_realtime.TripUpdate.StopTimeEvent.$Properties,
         writer?: $protobuf.Writer
       ): $protobuf.Writer;
 
@@ -593,39 +679,41 @@ export namespace transit_realtime {
        * Decodes a StopTimeEvent message from the specified reader or buffer.
        * @param reader Reader or buffer to decode from
        * @param [length] Message length if known beforehand
-       * @returns StopTimeEvent
+       * @returns {transit_realtime.TripUpdate.StopTimeEvent & transit_realtime.TripUpdate.StopTimeEvent.$Shape} StopTimeEvent
        * @throws {Error} If the payload is not a reader or valid buffer
        * @throws {$protobuf.util.ProtocolError} If required fields are missing
        */
-      public static decode(
+      static decode(
         reader: $protobuf.Reader | Uint8Array,
         length?: number
-      ): transit_realtime.TripUpdate.StopTimeEvent;
+      ): transit_realtime.TripUpdate.StopTimeEvent &
+        transit_realtime.TripUpdate.StopTimeEvent.$Shape;
 
       /**
        * Decodes a StopTimeEvent message from the specified reader or buffer, length delimited.
        * @param reader Reader or buffer to decode from
-       * @returns StopTimeEvent
+       * @returns {transit_realtime.TripUpdate.StopTimeEvent & transit_realtime.TripUpdate.StopTimeEvent.$Shape} StopTimeEvent
        * @throws {Error} If the payload is not a reader or valid buffer
        * @throws {$protobuf.util.ProtocolError} If required fields are missing
        */
-      public static decodeDelimited(
+      static decodeDelimited(
         reader: $protobuf.Reader | Uint8Array
-      ): transit_realtime.TripUpdate.StopTimeEvent;
+      ): transit_realtime.TripUpdate.StopTimeEvent &
+        transit_realtime.TripUpdate.StopTimeEvent.$Shape;
 
       /**
        * Verifies a StopTimeEvent message.
        * @param message Plain object to verify
        * @returns `null` if valid, otherwise the reason why it is not
        */
-      public static verify(message: { [k: string]: any }): string | null;
+      static verify(message: { [k: string]: any }): string | null;
 
       /**
        * Creates a StopTimeEvent message from a plain object. Also converts values to their respective internal types.
        * @param object Plain object
        * @returns StopTimeEvent
        */
-      public static fromObject(object: {
+      static fromObject(object: {
         [k: string]: any;
       }): transit_realtime.TripUpdate.StopTimeEvent;
 
@@ -635,7 +723,7 @@ export namespace transit_realtime {
        * @param [options] Conversion options
        * @returns Plain object
        */
-      public static toObject(
+      static toObject(
         message: transit_realtime.TripUpdate.StopTimeEvent,
         options?: $protobuf.IConversionOptions
       ): { [k: string]: any };
@@ -644,64 +732,82 @@ export namespace transit_realtime {
        * Converts this StopTimeEvent to JSON.
        * @returns JSON object
        */
-      public toJSON(): { [k: string]: any };
+      toJSON(): { [k: string]: any };
 
       /**
-       * Gets the default type url for StopTimeEvent
-       * @param [typeUrlPrefix] your custom typeUrlPrefix(default "type.googleapis.com")
-       * @returns The default type url
+       * Gets the type url for StopTimeEvent
+       * @param [prefix] Custom type url prefix, defaults to `"type.googleapis.com"`
+       * @returns The type url
        */
-      public static getTypeUrl(typeUrlPrefix?: string): string;
+      static getTypeUrl(prefix?: string): string;
     }
 
-    /** Properties of a StopTimeUpdate. */
-    interface IStopTimeUpdate {
-      /** StopTimeUpdate stopSequence */
-      stopSequence?: number | null;
+    namespace StopTimeEvent {
+      /** Properties of a StopTimeEvent. */
+      interface $Properties {
+        /** StopTimeEvent delay */
+        delay?: number | null;
 
-      /** StopTimeUpdate stopId */
-      stopId?: string | null;
+        /** StopTimeEvent time */
+        time?: number | Long | null;
 
-      /** StopTimeUpdate arrival */
-      arrival?: transit_realtime.TripUpdate.IStopTimeEvent | null;
+        /** StopTimeEvent uncertainty */
+        uncertainty?: number | null;
 
-      /** StopTimeUpdate departure */
-      departure?: transit_realtime.TripUpdate.IStopTimeEvent | null;
+        /** Unknown fields preserved while decoding */
+        $unknowns?: Uint8Array[];
+      }
 
-      /** StopTimeUpdate scheduleRelationship */
-      scheduleRelationship?: transit_realtime.TripUpdate.StopTimeUpdate.ScheduleRelationship | null;
+      /** Shape of a StopTimeEvent. */
+      type $Shape = transit_realtime.TripUpdate.StopTimeEvent.$Properties;
     }
+
+    /**
+     * Properties of a StopTimeUpdate.
+     * @deprecated Use transit_realtime.TripUpdate.StopTimeUpdate.$Properties instead.
+     */
+    interface IStopTimeUpdate
+      extends transit_realtime.TripUpdate.StopTimeUpdate.$Properties {}
 
     /** Represents a StopTimeUpdate. */
-    class StopTimeUpdate implements IStopTimeUpdate {
+    class StopTimeUpdate {
       /**
        * Constructs a new StopTimeUpdate.
        * @param [properties] Properties to set
        */
-      constructor(properties?: transit_realtime.TripUpdate.IStopTimeUpdate);
+      constructor(
+        properties?: transit_realtime.TripUpdate.StopTimeUpdate.$Properties
+      );
+
+      /** Unknown fields preserved while decoding */
+      $unknowns?: Uint8Array[];
 
       /** StopTimeUpdate stopSequence. */
-      public stopSequence: number;
+      stopSequence: number;
 
       /** StopTimeUpdate stopId. */
-      public stopId: string;
+      stopId: string;
 
       /** StopTimeUpdate arrival. */
-      public arrival?: transit_realtime.TripUpdate.IStopTimeEvent | null;
+      arrival?: transit_realtime.TripUpdate.StopTimeEvent.$Properties | null;
 
       /** StopTimeUpdate departure. */
-      public departure?: transit_realtime.TripUpdate.IStopTimeEvent | null;
+      departure?: transit_realtime.TripUpdate.StopTimeEvent.$Properties | null;
 
       /** StopTimeUpdate scheduleRelationship. */
-      public scheduleRelationship: transit_realtime.TripUpdate.StopTimeUpdate.ScheduleRelationship;
+      scheduleRelationship: transit_realtime.TripUpdate.StopTimeUpdate.ScheduleRelationship;
 
       /**
        * Creates a new StopTimeUpdate instance using the specified properties.
        * @param [properties] Properties to set
        * @returns StopTimeUpdate instance
        */
-      public static create(
-        properties?: transit_realtime.TripUpdate.IStopTimeUpdate
+      static create(
+        properties: transit_realtime.TripUpdate.StopTimeUpdate.$Shape
+      ): transit_realtime.TripUpdate.StopTimeUpdate &
+        transit_realtime.TripUpdate.StopTimeUpdate.$Shape;
+      static create(
+        properties?: transit_realtime.TripUpdate.StopTimeUpdate.$Properties
       ): transit_realtime.TripUpdate.StopTimeUpdate;
 
       /**
@@ -710,8 +816,8 @@ export namespace transit_realtime {
        * @param [writer] Writer to encode to
        * @returns Writer
        */
-      public static encode(
-        message: transit_realtime.TripUpdate.IStopTimeUpdate,
+      static encode(
+        message: transit_realtime.TripUpdate.StopTimeUpdate.$Properties,
         writer?: $protobuf.Writer
       ): $protobuf.Writer;
 
@@ -721,8 +827,8 @@ export namespace transit_realtime {
        * @param [writer] Writer to encode to
        * @returns Writer
        */
-      public static encodeDelimited(
-        message: transit_realtime.TripUpdate.IStopTimeUpdate,
+      static encodeDelimited(
+        message: transit_realtime.TripUpdate.StopTimeUpdate.$Properties,
         writer?: $protobuf.Writer
       ): $protobuf.Writer;
 
@@ -730,39 +836,41 @@ export namespace transit_realtime {
        * Decodes a StopTimeUpdate message from the specified reader or buffer.
        * @param reader Reader or buffer to decode from
        * @param [length] Message length if known beforehand
-       * @returns StopTimeUpdate
+       * @returns {transit_realtime.TripUpdate.StopTimeUpdate & transit_realtime.TripUpdate.StopTimeUpdate.$Shape} StopTimeUpdate
        * @throws {Error} If the payload is not a reader or valid buffer
        * @throws {$protobuf.util.ProtocolError} If required fields are missing
        */
-      public static decode(
+      static decode(
         reader: $protobuf.Reader | Uint8Array,
         length?: number
-      ): transit_realtime.TripUpdate.StopTimeUpdate;
+      ): transit_realtime.TripUpdate.StopTimeUpdate &
+        transit_realtime.TripUpdate.StopTimeUpdate.$Shape;
 
       /**
        * Decodes a StopTimeUpdate message from the specified reader or buffer, length delimited.
        * @param reader Reader or buffer to decode from
-       * @returns StopTimeUpdate
+       * @returns {transit_realtime.TripUpdate.StopTimeUpdate & transit_realtime.TripUpdate.StopTimeUpdate.$Shape} StopTimeUpdate
        * @throws {Error} If the payload is not a reader or valid buffer
        * @throws {$protobuf.util.ProtocolError} If required fields are missing
        */
-      public static decodeDelimited(
+      static decodeDelimited(
         reader: $protobuf.Reader | Uint8Array
-      ): transit_realtime.TripUpdate.StopTimeUpdate;
+      ): transit_realtime.TripUpdate.StopTimeUpdate &
+        transit_realtime.TripUpdate.StopTimeUpdate.$Shape;
 
       /**
        * Verifies a StopTimeUpdate message.
        * @param message Plain object to verify
        * @returns `null` if valid, otherwise the reason why it is not
        */
-      public static verify(message: { [k: string]: any }): string | null;
+      static verify(message: { [k: string]: any }): string | null;
 
       /**
        * Creates a StopTimeUpdate message from a plain object. Also converts values to their respective internal types.
        * @param object Plain object
        * @returns StopTimeUpdate
        */
-      public static fromObject(object: {
+      static fromObject(object: {
         [k: string]: any;
       }): transit_realtime.TripUpdate.StopTimeUpdate;
 
@@ -772,7 +880,7 @@ export namespace transit_realtime {
        * @param [options] Conversion options
        * @returns Plain object
        */
-      public static toObject(
+      static toObject(
         message: transit_realtime.TripUpdate.StopTimeUpdate,
         options?: $protobuf.IConversionOptions
       ): { [k: string]: any };
@@ -781,98 +889,111 @@ export namespace transit_realtime {
        * Converts this StopTimeUpdate to JSON.
        * @returns JSON object
        */
-      public toJSON(): { [k: string]: any };
+      toJSON(): { [k: string]: any };
 
       /**
-       * Gets the default type url for StopTimeUpdate
-       * @param [typeUrlPrefix] your custom typeUrlPrefix(default "type.googleapis.com")
-       * @returns The default type url
+       * Gets the type url for StopTimeUpdate
+       * @param [prefix] Custom type url prefix, defaults to `"type.googleapis.com"`
+       * @returns The type url
        */
-      public static getTypeUrl(typeUrlPrefix?: string): string;
+      static getTypeUrl(prefix?: string): string;
     }
 
     namespace StopTimeUpdate {
+      /** Properties of a StopTimeUpdate. */
+      interface $Properties {
+        /** StopTimeUpdate stopSequence */
+        stopSequence?: number | null;
+
+        /** StopTimeUpdate stopId */
+        stopId?: string | null;
+
+        /** StopTimeUpdate arrival */
+        arrival?: transit_realtime.TripUpdate.StopTimeEvent.$Properties | null;
+
+        /** StopTimeUpdate departure */
+        departure?: transit_realtime.TripUpdate.StopTimeEvent.$Properties | null;
+
+        /** StopTimeUpdate scheduleRelationship */
+        scheduleRelationship?: transit_realtime.TripUpdate.StopTimeUpdate.ScheduleRelationship | null;
+
+        /** Unknown fields preserved while decoding */
+        $unknowns?: Uint8Array[];
+      }
+
+      /** Shape of a StopTimeUpdate. */
+      type $Shape = transit_realtime.TripUpdate.StopTimeUpdate.$Properties;
+
       /** ScheduleRelationship enum. */
       enum ScheduleRelationship {
+        /** SCHEDULED value */
         SCHEDULED = 0,
+
+        /** SKIPPED value */
         SKIPPED = 1,
+
+        /** NO_DATA value */
         NO_DATA = 2,
       }
     }
   }
 
-  /** Properties of a VehiclePosition. */
-  interface IVehiclePosition {
-    /** VehiclePosition trip */
-    trip?: transit_realtime.ITripDescriptor | null;
-
-    /** VehiclePosition vehicle */
-    vehicle?: transit_realtime.IVehicleDescriptor | null;
-
-    /** VehiclePosition position */
-    position?: transit_realtime.IPosition | null;
-
-    /** VehiclePosition currentStopSequence */
-    currentStopSequence?: number | null;
-
-    /** VehiclePosition stopId */
-    stopId?: string | null;
-
-    /** VehiclePosition currentStatus */
-    currentStatus?: transit_realtime.VehiclePosition.VehicleStopStatus | null;
-
-    /** VehiclePosition timestamp */
-    timestamp?: number | Long | null;
-
-    /** VehiclePosition congestionLevel */
-    congestionLevel?: transit_realtime.VehiclePosition.CongestionLevel | null;
-
-    /** VehiclePosition occupancyStatus */
-    occupancyStatus?: transit_realtime.VehiclePosition.OccupancyStatus | null;
-  }
+  /**
+   * Properties of a VehiclePosition.
+   * @deprecated Use transit_realtime.VehiclePosition.$Properties instead.
+   */
+  interface IVehiclePosition
+    extends transit_realtime.VehiclePosition.$Properties {}
 
   /** Represents a VehiclePosition. */
-  class VehiclePosition implements IVehiclePosition {
+  class VehiclePosition {
     /**
      * Constructs a new VehiclePosition.
      * @param [properties] Properties to set
      */
-    constructor(properties?: transit_realtime.IVehiclePosition);
+    constructor(properties?: transit_realtime.VehiclePosition.$Properties);
+
+    /** Unknown fields preserved while decoding */
+    $unknowns?: Uint8Array[];
 
     /** VehiclePosition trip. */
-    public trip?: transit_realtime.ITripDescriptor | null;
+    trip?: transit_realtime.TripDescriptor.$Properties | null;
 
     /** VehiclePosition vehicle. */
-    public vehicle?: transit_realtime.IVehicleDescriptor | null;
+    vehicle?: transit_realtime.VehicleDescriptor.$Properties | null;
 
     /** VehiclePosition position. */
-    public position?: transit_realtime.IPosition | null;
+    position?: transit_realtime.Position.$Properties | null;
 
     /** VehiclePosition currentStopSequence. */
-    public currentStopSequence: number;
+    currentStopSequence: number;
 
     /** VehiclePosition stopId. */
-    public stopId: string;
+    stopId: string;
 
     /** VehiclePosition currentStatus. */
-    public currentStatus: transit_realtime.VehiclePosition.VehicleStopStatus;
+    currentStatus: transit_realtime.VehiclePosition.VehicleStopStatus;
 
     /** VehiclePosition timestamp. */
-    public timestamp: number | Long;
+    timestamp: number | Long;
 
     /** VehiclePosition congestionLevel. */
-    public congestionLevel: transit_realtime.VehiclePosition.CongestionLevel;
+    congestionLevel: transit_realtime.VehiclePosition.CongestionLevel;
 
     /** VehiclePosition occupancyStatus. */
-    public occupancyStatus: transit_realtime.VehiclePosition.OccupancyStatus;
+    occupancyStatus: transit_realtime.VehiclePosition.OccupancyStatus;
 
     /**
      * Creates a new VehiclePosition instance using the specified properties.
      * @param [properties] Properties to set
      * @returns VehiclePosition instance
      */
-    public static create(
-      properties?: transit_realtime.IVehiclePosition
+    static create(
+      properties: transit_realtime.VehiclePosition.$Shape
+    ): transit_realtime.VehiclePosition &
+      transit_realtime.VehiclePosition.$Shape;
+    static create(
+      properties?: transit_realtime.VehiclePosition.$Properties
     ): transit_realtime.VehiclePosition;
 
     /**
@@ -881,8 +1002,8 @@ export namespace transit_realtime {
      * @param [writer] Writer to encode to
      * @returns Writer
      */
-    public static encode(
-      message: transit_realtime.IVehiclePosition,
+    static encode(
+      message: transit_realtime.VehiclePosition.$Properties,
       writer?: $protobuf.Writer
     ): $protobuf.Writer;
 
@@ -892,8 +1013,8 @@ export namespace transit_realtime {
      * @param [writer] Writer to encode to
      * @returns Writer
      */
-    public static encodeDelimited(
-      message: transit_realtime.IVehiclePosition,
+    static encodeDelimited(
+      message: transit_realtime.VehiclePosition.$Properties,
       writer?: $protobuf.Writer
     ): $protobuf.Writer;
 
@@ -901,39 +1022,41 @@ export namespace transit_realtime {
      * Decodes a VehiclePosition message from the specified reader or buffer.
      * @param reader Reader or buffer to decode from
      * @param [length] Message length if known beforehand
-     * @returns VehiclePosition
+     * @returns {transit_realtime.VehiclePosition & transit_realtime.VehiclePosition.$Shape} VehiclePosition
      * @throws {Error} If the payload is not a reader or valid buffer
      * @throws {$protobuf.util.ProtocolError} If required fields are missing
      */
-    public static decode(
+    static decode(
       reader: $protobuf.Reader | Uint8Array,
       length?: number
-    ): transit_realtime.VehiclePosition;
+    ): transit_realtime.VehiclePosition &
+      transit_realtime.VehiclePosition.$Shape;
 
     /**
      * Decodes a VehiclePosition message from the specified reader or buffer, length delimited.
      * @param reader Reader or buffer to decode from
-     * @returns VehiclePosition
+     * @returns {transit_realtime.VehiclePosition & transit_realtime.VehiclePosition.$Shape} VehiclePosition
      * @throws {Error} If the payload is not a reader or valid buffer
      * @throws {$protobuf.util.ProtocolError} If required fields are missing
      */
-    public static decodeDelimited(
+    static decodeDelimited(
       reader: $protobuf.Reader | Uint8Array
-    ): transit_realtime.VehiclePosition;
+    ): transit_realtime.VehiclePosition &
+      transit_realtime.VehiclePosition.$Shape;
 
     /**
      * Verifies a VehiclePosition message.
      * @param message Plain object to verify
      * @returns `null` if valid, otherwise the reason why it is not
      */
-    public static verify(message: { [k: string]: any }): string | null;
+    static verify(message: { [k: string]: any }): string | null;
 
     /**
      * Creates a VehiclePosition message from a plain object. Also converts values to their respective internal types.
      * @param object Plain object
      * @returns VehiclePosition
      */
-    public static fromObject(object: {
+    static fromObject(object: {
       [k: string]: any;
     }): transit_realtime.VehiclePosition;
 
@@ -943,7 +1066,7 @@ export namespace transit_realtime {
      * @param [options] Conversion options
      * @returns Plain object
      */
-    public static toObject(
+    static toObject(
       message: transit_realtime.VehiclePosition,
       options?: $protobuf.IConversionOptions
     ): { [k: string]: any };
@@ -952,105 +1075,156 @@ export namespace transit_realtime {
      * Converts this VehiclePosition to JSON.
      * @returns JSON object
      */
-    public toJSON(): { [k: string]: any };
+    toJSON(): { [k: string]: any };
 
     /**
-     * Gets the default type url for VehiclePosition
-     * @param [typeUrlPrefix] your custom typeUrlPrefix(default "type.googleapis.com")
-     * @returns The default type url
+     * Gets the type url for VehiclePosition
+     * @param [prefix] Custom type url prefix, defaults to `"type.googleapis.com"`
+     * @returns The type url
      */
-    public static getTypeUrl(typeUrlPrefix?: string): string;
+    static getTypeUrl(prefix?: string): string;
   }
 
   namespace VehiclePosition {
+    /** Properties of a VehiclePosition. */
+    interface $Properties {
+      /** VehiclePosition trip */
+      trip?: transit_realtime.TripDescriptor.$Properties | null;
+
+      /** VehiclePosition vehicle */
+      vehicle?: transit_realtime.VehicleDescriptor.$Properties | null;
+
+      /** VehiclePosition position */
+      position?: transit_realtime.Position.$Properties | null;
+
+      /** VehiclePosition currentStopSequence */
+      currentStopSequence?: number | null;
+
+      /** VehiclePosition stopId */
+      stopId?: string | null;
+
+      /** VehiclePosition currentStatus */
+      currentStatus?: transit_realtime.VehiclePosition.VehicleStopStatus | null;
+
+      /** VehiclePosition timestamp */
+      timestamp?: number | Long | null;
+
+      /** VehiclePosition congestionLevel */
+      congestionLevel?: transit_realtime.VehiclePosition.CongestionLevel | null;
+
+      /** VehiclePosition occupancyStatus */
+      occupancyStatus?: transit_realtime.VehiclePosition.OccupancyStatus | null;
+
+      /** Unknown fields preserved while decoding */
+      $unknowns?: Uint8Array[];
+    }
+
+    /** Shape of a VehiclePosition. */
+    type $Shape = transit_realtime.VehiclePosition.$Properties;
+
     /** VehicleStopStatus enum. */
     enum VehicleStopStatus {
+      /** INCOMING_AT value */
       INCOMING_AT = 0,
+
+      /** STOPPED_AT value */
       STOPPED_AT = 1,
+
+      /** IN_TRANSIT_TO value */
       IN_TRANSIT_TO = 2,
     }
 
     /** CongestionLevel enum. */
     enum CongestionLevel {
+      /** UNKNOWN_CONGESTION_LEVEL value */
       UNKNOWN_CONGESTION_LEVEL = 0,
+
+      /** RUNNING_SMOOTHLY value */
       RUNNING_SMOOTHLY = 1,
+
+      /** STOP_AND_GO value */
       STOP_AND_GO = 2,
+
+      /** CONGESTION value */
       CONGESTION = 3,
+
+      /** SEVERE_CONGESTION value */
       SEVERE_CONGESTION = 4,
     }
 
     /** OccupancyStatus enum. */
     enum OccupancyStatus {
+      /** EMPTY value */
       EMPTY = 0,
+
+      /** MANY_SEATS_AVAILABLE value */
       MANY_SEATS_AVAILABLE = 1,
+
+      /** FEW_SEATS_AVAILABLE value */
       FEW_SEATS_AVAILABLE = 2,
+
+      /** STANDING_ROOM_ONLY value */
       STANDING_ROOM_ONLY = 3,
+
+      /** CRUSHED_STANDING_ROOM_ONLY value */
       CRUSHED_STANDING_ROOM_ONLY = 4,
+
+      /** FULL value */
       FULL = 5,
+
+      /** NOT_ACCEPTING_PASSENGERS value */
       NOT_ACCEPTING_PASSENGERS = 6,
     }
   }
 
-  /** Properties of an Alert. */
-  interface IAlert {
-    /** Alert activePeriod */
-    activePeriod?: transit_realtime.ITimeRange[] | null;
-
-    /** Alert informedEntity */
-    informedEntity?: transit_realtime.IEntitySelector[] | null;
-
-    /** Alert cause */
-    cause?: transit_realtime.Alert.Cause | null;
-
-    /** Alert effect */
-    effect?: transit_realtime.Alert.Effect | null;
-
-    /** Alert url */
-    url?: transit_realtime.ITranslatedString | null;
-
-    /** Alert headerText */
-    headerText?: transit_realtime.ITranslatedString | null;
-
-    /** Alert descriptionText */
-    descriptionText?: transit_realtime.ITranslatedString | null;
-  }
+  /**
+   * Properties of an Alert.
+   * @deprecated Use transit_realtime.Alert.$Properties instead.
+   */
+  interface IAlert extends transit_realtime.Alert.$Properties {}
 
   /** Represents an Alert. */
-  class Alert implements IAlert {
+  class Alert {
     /**
      * Constructs a new Alert.
      * @param [properties] Properties to set
      */
-    constructor(properties?: transit_realtime.IAlert);
+    constructor(properties?: transit_realtime.Alert.$Properties);
+
+    /** Unknown fields preserved while decoding */
+    $unknowns?: Uint8Array[];
 
     /** Alert activePeriod. */
-    public activePeriod: transit_realtime.ITimeRange[];
+    activePeriod: transit_realtime.TimeRange.$Properties[];
 
     /** Alert informedEntity. */
-    public informedEntity: transit_realtime.IEntitySelector[];
+    informedEntity: transit_realtime.EntitySelector.$Properties[];
 
     /** Alert cause. */
-    public cause: transit_realtime.Alert.Cause;
+    cause: transit_realtime.Alert.Cause;
 
     /** Alert effect. */
-    public effect: transit_realtime.Alert.Effect;
+    effect: transit_realtime.Alert.Effect;
 
     /** Alert url. */
-    public url?: transit_realtime.ITranslatedString | null;
+    url?: transit_realtime.TranslatedString.$Properties | null;
 
     /** Alert headerText. */
-    public headerText?: transit_realtime.ITranslatedString | null;
+    headerText?: transit_realtime.TranslatedString.$Properties | null;
 
     /** Alert descriptionText. */
-    public descriptionText?: transit_realtime.ITranslatedString | null;
+    descriptionText?: transit_realtime.TranslatedString.$Properties | null;
 
     /**
      * Creates a new Alert instance using the specified properties.
      * @param [properties] Properties to set
      * @returns Alert instance
      */
-    public static create(
-      properties?: transit_realtime.IAlert
+    static create(
+      properties: transit_realtime.Alert.$Shape
+    ): transit_realtime.Alert & transit_realtime.Alert.$Shape;
+    static create(
+      properties?: transit_realtime.Alert.$Properties
     ): transit_realtime.Alert;
 
     /**
@@ -1059,8 +1233,8 @@ export namespace transit_realtime {
      * @param [writer] Writer to encode to
      * @returns Writer
      */
-    public static encode(
-      message: transit_realtime.IAlert,
+    static encode(
+      message: transit_realtime.Alert.$Properties,
       writer?: $protobuf.Writer
     ): $protobuf.Writer;
 
@@ -1070,8 +1244,8 @@ export namespace transit_realtime {
      * @param [writer] Writer to encode to
      * @returns Writer
      */
-    public static encodeDelimited(
-      message: transit_realtime.IAlert,
+    static encodeDelimited(
+      message: transit_realtime.Alert.$Properties,
       writer?: $protobuf.Writer
     ): $protobuf.Writer;
 
@@ -1079,41 +1253,39 @@ export namespace transit_realtime {
      * Decodes an Alert message from the specified reader or buffer.
      * @param reader Reader or buffer to decode from
      * @param [length] Message length if known beforehand
-     * @returns Alert
+     * @returns {transit_realtime.Alert & transit_realtime.Alert.$Shape} Alert
      * @throws {Error} If the payload is not a reader or valid buffer
      * @throws {$protobuf.util.ProtocolError} If required fields are missing
      */
-    public static decode(
+    static decode(
       reader: $protobuf.Reader | Uint8Array,
       length?: number
-    ): transit_realtime.Alert;
+    ): transit_realtime.Alert & transit_realtime.Alert.$Shape;
 
     /**
      * Decodes an Alert message from the specified reader or buffer, length delimited.
      * @param reader Reader or buffer to decode from
-     * @returns Alert
+     * @returns {transit_realtime.Alert & transit_realtime.Alert.$Shape} Alert
      * @throws {Error} If the payload is not a reader or valid buffer
      * @throws {$protobuf.util.ProtocolError} If required fields are missing
      */
-    public static decodeDelimited(
+    static decodeDelimited(
       reader: $protobuf.Reader | Uint8Array
-    ): transit_realtime.Alert;
+    ): transit_realtime.Alert & transit_realtime.Alert.$Shape;
 
     /**
      * Verifies an Alert message.
      * @param message Plain object to verify
      * @returns `null` if valid, otherwise the reason why it is not
      */
-    public static verify(message: { [k: string]: any }): string | null;
+    static verify(message: { [k: string]: any }): string | null;
 
     /**
      * Creates an Alert message from a plain object. Also converts values to their respective internal types.
      * @param object Plain object
      * @returns Alert
      */
-    public static fromObject(object: {
-      [k: string]: any;
-    }): transit_realtime.Alert;
+    static fromObject(object: { [k: string]: any }): transit_realtime.Alert;
 
     /**
      * Creates a plain object from an Alert message. Also converts values to other types if specified.
@@ -1121,7 +1293,7 @@ export namespace transit_realtime {
      * @param [options] Conversion options
      * @returns Plain object
      */
-    public static toObject(
+    static toObject(
       message: transit_realtime.Alert,
       options?: $protobuf.IConversionOptions
     ): { [k: string]: any };
@@ -1130,77 +1302,150 @@ export namespace transit_realtime {
      * Converts this Alert to JSON.
      * @returns JSON object
      */
-    public toJSON(): { [k: string]: any };
+    toJSON(): { [k: string]: any };
 
     /**
-     * Gets the default type url for Alert
-     * @param [typeUrlPrefix] your custom typeUrlPrefix(default "type.googleapis.com")
-     * @returns The default type url
+     * Gets the type url for Alert
+     * @param [prefix] Custom type url prefix, defaults to `"type.googleapis.com"`
+     * @returns The type url
      */
-    public static getTypeUrl(typeUrlPrefix?: string): string;
+    static getTypeUrl(prefix?: string): string;
   }
 
   namespace Alert {
+    /** Properties of an Alert. */
+    interface $Properties {
+      /** Alert activePeriod */
+      activePeriod?: transit_realtime.TimeRange.$Properties[] | null;
+
+      /** Alert informedEntity */
+      informedEntity?: transit_realtime.EntitySelector.$Properties[] | null;
+
+      /** Alert cause */
+      cause?: transit_realtime.Alert.Cause | null;
+
+      /** Alert effect */
+      effect?: transit_realtime.Alert.Effect | null;
+
+      /** Alert url */
+      url?: transit_realtime.TranslatedString.$Properties | null;
+
+      /** Alert headerText */
+      headerText?: transit_realtime.TranslatedString.$Properties | null;
+
+      /** Alert descriptionText */
+      descriptionText?: transit_realtime.TranslatedString.$Properties | null;
+
+      /** Unknown fields preserved while decoding */
+      $unknowns?: Uint8Array[];
+    }
+
+    /** Shape of an Alert. */
+    type $Shape = transit_realtime.Alert.$Properties;
+
     /** Cause enum. */
     enum Cause {
+      /** UNKNOWN_CAUSE value */
       UNKNOWN_CAUSE = 1,
+
+      /** OTHER_CAUSE value */
       OTHER_CAUSE = 2,
+
+      /** TECHNICAL_PROBLEM value */
       TECHNICAL_PROBLEM = 3,
+
+      /** STRIKE value */
       STRIKE = 4,
+
+      /** DEMONSTRATION value */
       DEMONSTRATION = 5,
+
+      /** ACCIDENT value */
       ACCIDENT = 6,
+
+      /** HOLIDAY value */
       HOLIDAY = 7,
+
+      /** WEATHER value */
       WEATHER = 8,
+
+      /** MAINTENANCE value */
       MAINTENANCE = 9,
+
+      /** CONSTRUCTION value */
       CONSTRUCTION = 10,
+
+      /** POLICE_ACTIVITY value */
       POLICE_ACTIVITY = 11,
+
+      /** MEDICAL_EMERGENCY value */
       MEDICAL_EMERGENCY = 12,
     }
 
     /** Effect enum. */
     enum Effect {
+      /** NO_SERVICE value */
       NO_SERVICE = 1,
+
+      /** REDUCED_SERVICE value */
       REDUCED_SERVICE = 2,
+
+      /** SIGNIFICANT_DELAYS value */
       SIGNIFICANT_DELAYS = 3,
+
+      /** DETOUR value */
       DETOUR = 4,
+
+      /** ADDITIONAL_SERVICE value */
       ADDITIONAL_SERVICE = 5,
+
+      /** MODIFIED_SERVICE value */
       MODIFIED_SERVICE = 6,
+
+      /** OTHER_EFFECT value */
       OTHER_EFFECT = 7,
+
+      /** UNKNOWN_EFFECT value */
       UNKNOWN_EFFECT = 8,
+
+      /** STOP_MOVED value */
       STOP_MOVED = 9,
     }
   }
 
-  /** Properties of a TimeRange. */
-  interface ITimeRange {
-    /** TimeRange start */
-    start?: number | Long | null;
-
-    /** TimeRange end */
-    end?: number | Long | null;
-  }
+  /**
+   * Properties of a TimeRange.
+   * @deprecated Use transit_realtime.TimeRange.$Properties instead.
+   */
+  interface ITimeRange extends transit_realtime.TimeRange.$Properties {}
 
   /** Represents a TimeRange. */
-  class TimeRange implements ITimeRange {
+  class TimeRange {
     /**
      * Constructs a new TimeRange.
      * @param [properties] Properties to set
      */
-    constructor(properties?: transit_realtime.ITimeRange);
+    constructor(properties?: transit_realtime.TimeRange.$Properties);
+
+    /** Unknown fields preserved while decoding */
+    $unknowns?: Uint8Array[];
 
     /** TimeRange start. */
-    public start: number | Long;
+    start: number | Long;
 
     /** TimeRange end. */
-    public end: number | Long;
+    end: number | Long;
 
     /**
      * Creates a new TimeRange instance using the specified properties.
      * @param [properties] Properties to set
      * @returns TimeRange instance
      */
-    public static create(
-      properties?: transit_realtime.ITimeRange
+    static create(
+      properties: transit_realtime.TimeRange.$Shape
+    ): transit_realtime.TimeRange & transit_realtime.TimeRange.$Shape;
+    static create(
+      properties?: transit_realtime.TimeRange.$Properties
     ): transit_realtime.TimeRange;
 
     /**
@@ -1209,8 +1454,8 @@ export namespace transit_realtime {
      * @param [writer] Writer to encode to
      * @returns Writer
      */
-    public static encode(
-      message: transit_realtime.ITimeRange,
+    static encode(
+      message: transit_realtime.TimeRange.$Properties,
       writer?: $protobuf.Writer
     ): $protobuf.Writer;
 
@@ -1220,8 +1465,8 @@ export namespace transit_realtime {
      * @param [writer] Writer to encode to
      * @returns Writer
      */
-    public static encodeDelimited(
-      message: transit_realtime.ITimeRange,
+    static encodeDelimited(
+      message: transit_realtime.TimeRange.$Properties,
       writer?: $protobuf.Writer
     ): $protobuf.Writer;
 
@@ -1229,41 +1474,39 @@ export namespace transit_realtime {
      * Decodes a TimeRange message from the specified reader or buffer.
      * @param reader Reader or buffer to decode from
      * @param [length] Message length if known beforehand
-     * @returns TimeRange
+     * @returns {transit_realtime.TimeRange & transit_realtime.TimeRange.$Shape} TimeRange
      * @throws {Error} If the payload is not a reader or valid buffer
      * @throws {$protobuf.util.ProtocolError} If required fields are missing
      */
-    public static decode(
+    static decode(
       reader: $protobuf.Reader | Uint8Array,
       length?: number
-    ): transit_realtime.TimeRange;
+    ): transit_realtime.TimeRange & transit_realtime.TimeRange.$Shape;
 
     /**
      * Decodes a TimeRange message from the specified reader or buffer, length delimited.
      * @param reader Reader or buffer to decode from
-     * @returns TimeRange
+     * @returns {transit_realtime.TimeRange & transit_realtime.TimeRange.$Shape} TimeRange
      * @throws {Error} If the payload is not a reader or valid buffer
      * @throws {$protobuf.util.ProtocolError} If required fields are missing
      */
-    public static decodeDelimited(
+    static decodeDelimited(
       reader: $protobuf.Reader | Uint8Array
-    ): transit_realtime.TimeRange;
+    ): transit_realtime.TimeRange & transit_realtime.TimeRange.$Shape;
 
     /**
      * Verifies a TimeRange message.
      * @param message Plain object to verify
      * @returns `null` if valid, otherwise the reason why it is not
      */
-    public static verify(message: { [k: string]: any }): string | null;
+    static verify(message: { [k: string]: any }): string | null;
 
     /**
      * Creates a TimeRange message from a plain object. Also converts values to their respective internal types.
      * @param object Plain object
      * @returns TimeRange
      */
-    public static fromObject(object: {
-      [k: string]: any;
-    }): transit_realtime.TimeRange;
+    static fromObject(object: { [k: string]: any }): transit_realtime.TimeRange;
 
     /**
      * Creates a plain object from a TimeRange message. Also converts values to other types if specified.
@@ -1271,7 +1514,7 @@ export namespace transit_realtime {
      * @param [options] Conversion options
      * @returns Plain object
      */
-    public static toObject(
+    static toObject(
       message: transit_realtime.TimeRange,
       options?: $protobuf.IConversionOptions
     ): { [k: string]: any };
@@ -1280,64 +1523,75 @@ export namespace transit_realtime {
      * Converts this TimeRange to JSON.
      * @returns JSON object
      */
-    public toJSON(): { [k: string]: any };
+    toJSON(): { [k: string]: any };
 
     /**
-     * Gets the default type url for TimeRange
-     * @param [typeUrlPrefix] your custom typeUrlPrefix(default "type.googleapis.com")
-     * @returns The default type url
+     * Gets the type url for TimeRange
+     * @param [prefix] Custom type url prefix, defaults to `"type.googleapis.com"`
+     * @returns The type url
      */
-    public static getTypeUrl(typeUrlPrefix?: string): string;
+    static getTypeUrl(prefix?: string): string;
   }
 
-  /** Properties of a Position. */
-  interface IPosition {
-    /** Position latitude */
-    latitude: number;
+  namespace TimeRange {
+    /** Properties of a TimeRange. */
+    interface $Properties {
+      /** TimeRange start */
+      start?: number | Long | null;
 
-    /** Position longitude */
-    longitude: number;
+      /** TimeRange end */
+      end?: number | Long | null;
 
-    /** Position bearing */
-    bearing?: number | null;
+      /** Unknown fields preserved while decoding */
+      $unknowns?: Uint8Array[];
+    }
 
-    /** Position odometer */
-    odometer?: number | null;
-
-    /** Position speed */
-    speed?: number | null;
+    /** Shape of a TimeRange. */
+    type $Shape = transit_realtime.TimeRange.$Properties;
   }
+
+  /**
+   * Properties of a Position.
+   * @deprecated Use transit_realtime.Position.$Properties instead.
+   */
+  interface IPosition extends transit_realtime.Position.$Properties {}
 
   /** Represents a Position. */
-  class Position implements IPosition {
+  class Position {
     /**
      * Constructs a new Position.
      * @param [properties] Properties to set
      */
-    constructor(properties?: transit_realtime.IPosition);
+    constructor(properties?: transit_realtime.Position.$Properties);
+
+    /** Unknown fields preserved while decoding */
+    $unknowns?: Uint8Array[];
 
     /** Position latitude. */
-    public latitude: number;
+    latitude: number;
 
     /** Position longitude. */
-    public longitude: number;
+    longitude: number;
 
     /** Position bearing. */
-    public bearing: number;
+    bearing: number;
 
     /** Position odometer. */
-    public odometer: number;
+    odometer: number;
 
     /** Position speed. */
-    public speed: number;
+    speed: number;
 
     /**
      * Creates a new Position instance using the specified properties.
      * @param [properties] Properties to set
      * @returns Position instance
      */
-    public static create(
-      properties?: transit_realtime.IPosition
+    static create(
+      properties: transit_realtime.Position.$Shape
+    ): transit_realtime.Position & transit_realtime.Position.$Shape;
+    static create(
+      properties?: transit_realtime.Position.$Properties
     ): transit_realtime.Position;
 
     /**
@@ -1346,8 +1600,8 @@ export namespace transit_realtime {
      * @param [writer] Writer to encode to
      * @returns Writer
      */
-    public static encode(
-      message: transit_realtime.IPosition,
+    static encode(
+      message: transit_realtime.Position.$Properties,
       writer?: $protobuf.Writer
     ): $protobuf.Writer;
 
@@ -1357,8 +1611,8 @@ export namespace transit_realtime {
      * @param [writer] Writer to encode to
      * @returns Writer
      */
-    public static encodeDelimited(
-      message: transit_realtime.IPosition,
+    static encodeDelimited(
+      message: transit_realtime.Position.$Properties,
       writer?: $protobuf.Writer
     ): $protobuf.Writer;
 
@@ -1366,41 +1620,39 @@ export namespace transit_realtime {
      * Decodes a Position message from the specified reader or buffer.
      * @param reader Reader or buffer to decode from
      * @param [length] Message length if known beforehand
-     * @returns Position
+     * @returns {transit_realtime.Position & transit_realtime.Position.$Shape} Position
      * @throws {Error} If the payload is not a reader or valid buffer
      * @throws {$protobuf.util.ProtocolError} If required fields are missing
      */
-    public static decode(
+    static decode(
       reader: $protobuf.Reader | Uint8Array,
       length?: number
-    ): transit_realtime.Position;
+    ): transit_realtime.Position & transit_realtime.Position.$Shape;
 
     /**
      * Decodes a Position message from the specified reader or buffer, length delimited.
      * @param reader Reader or buffer to decode from
-     * @returns Position
+     * @returns {transit_realtime.Position & transit_realtime.Position.$Shape} Position
      * @throws {Error} If the payload is not a reader or valid buffer
      * @throws {$protobuf.util.ProtocolError} If required fields are missing
      */
-    public static decodeDelimited(
+    static decodeDelimited(
       reader: $protobuf.Reader | Uint8Array
-    ): transit_realtime.Position;
+    ): transit_realtime.Position & transit_realtime.Position.$Shape;
 
     /**
      * Verifies a Position message.
      * @param message Plain object to verify
      * @returns `null` if valid, otherwise the reason why it is not
      */
-    public static verify(message: { [k: string]: any }): string | null;
+    static verify(message: { [k: string]: any }): string | null;
 
     /**
      * Creates a Position message from a plain object. Also converts values to their respective internal types.
      * @param object Plain object
      * @returns Position
      */
-    public static fromObject(object: {
-      [k: string]: any;
-    }): transit_realtime.Position;
+    static fromObject(object: { [k: string]: any }): transit_realtime.Position;
 
     /**
      * Creates a plain object from a Position message. Also converts values to other types if specified.
@@ -1408,7 +1660,7 @@ export namespace transit_realtime {
      * @param [options] Conversion options
      * @returns Plain object
      */
-    public static toObject(
+    static toObject(
       message: transit_realtime.Position,
       options?: $protobuf.IConversionOptions
     ): { [k: string]: any };
@@ -1417,70 +1669,88 @@ export namespace transit_realtime {
      * Converts this Position to JSON.
      * @returns JSON object
      */
-    public toJSON(): { [k: string]: any };
+    toJSON(): { [k: string]: any };
 
     /**
-     * Gets the default type url for Position
-     * @param [typeUrlPrefix] your custom typeUrlPrefix(default "type.googleapis.com")
-     * @returns The default type url
+     * Gets the type url for Position
+     * @param [prefix] Custom type url prefix, defaults to `"type.googleapis.com"`
+     * @returns The type url
      */
-    public static getTypeUrl(typeUrlPrefix?: string): string;
+    static getTypeUrl(prefix?: string): string;
   }
 
-  /** Properties of a TripDescriptor. */
-  interface ITripDescriptor {
-    /** TripDescriptor tripId */
-    tripId?: string | null;
+  namespace Position {
+    /** Properties of a Position. */
+    interface $Properties {
+      /** Position latitude */
+      latitude: number;
 
-    /** TripDescriptor routeId */
-    routeId?: string | null;
+      /** Position longitude */
+      longitude: number;
 
-    /** TripDescriptor directionId */
-    directionId?: number | null;
+      /** Position bearing */
+      bearing?: number | null;
 
-    /** TripDescriptor startTime */
-    startTime?: string | null;
+      /** Position odometer */
+      odometer?: number | null;
 
-    /** TripDescriptor startDate */
-    startDate?: string | null;
+      /** Position speed */
+      speed?: number | null;
 
-    /** TripDescriptor scheduleRelationship */
-    scheduleRelationship?: transit_realtime.TripDescriptor.ScheduleRelationship | null;
+      /** Unknown fields preserved while decoding */
+      $unknowns?: Uint8Array[];
+    }
+
+    /** Shape of a Position. */
+    type $Shape = transit_realtime.Position.$Properties;
   }
+
+  /**
+   * Properties of a TripDescriptor.
+   * @deprecated Use transit_realtime.TripDescriptor.$Properties instead.
+   */
+  interface ITripDescriptor
+    extends transit_realtime.TripDescriptor.$Properties {}
 
   /** Represents a TripDescriptor. */
-  class TripDescriptor implements ITripDescriptor {
+  class TripDescriptor {
     /**
      * Constructs a new TripDescriptor.
      * @param [properties] Properties to set
      */
-    constructor(properties?: transit_realtime.ITripDescriptor);
+    constructor(properties?: transit_realtime.TripDescriptor.$Properties);
+
+    /** Unknown fields preserved while decoding */
+    $unknowns?: Uint8Array[];
 
     /** TripDescriptor tripId. */
-    public tripId: string;
+    tripId: string;
 
     /** TripDescriptor routeId. */
-    public routeId: string;
+    routeId: string;
 
     /** TripDescriptor directionId. */
-    public directionId: number;
+    directionId: number;
 
     /** TripDescriptor startTime. */
-    public startTime: string;
+    startTime: string;
 
     /** TripDescriptor startDate. */
-    public startDate: string;
+    startDate: string;
 
     /** TripDescriptor scheduleRelationship. */
-    public scheduleRelationship: transit_realtime.TripDescriptor.ScheduleRelationship;
+    scheduleRelationship: transit_realtime.TripDescriptor.ScheduleRelationship;
 
     /**
      * Creates a new TripDescriptor instance using the specified properties.
      * @param [properties] Properties to set
      * @returns TripDescriptor instance
      */
-    public static create(
-      properties?: transit_realtime.ITripDescriptor
+    static create(
+      properties: transit_realtime.TripDescriptor.$Shape
+    ): transit_realtime.TripDescriptor & transit_realtime.TripDescriptor.$Shape;
+    static create(
+      properties?: transit_realtime.TripDescriptor.$Properties
     ): transit_realtime.TripDescriptor;
 
     /**
@@ -1489,8 +1759,8 @@ export namespace transit_realtime {
      * @param [writer] Writer to encode to
      * @returns Writer
      */
-    public static encode(
-      message: transit_realtime.ITripDescriptor,
+    static encode(
+      message: transit_realtime.TripDescriptor.$Properties,
       writer?: $protobuf.Writer
     ): $protobuf.Writer;
 
@@ -1500,8 +1770,8 @@ export namespace transit_realtime {
      * @param [writer] Writer to encode to
      * @returns Writer
      */
-    public static encodeDelimited(
-      message: transit_realtime.ITripDescriptor,
+    static encodeDelimited(
+      message: transit_realtime.TripDescriptor.$Properties,
       writer?: $protobuf.Writer
     ): $protobuf.Writer;
 
@@ -1509,39 +1779,39 @@ export namespace transit_realtime {
      * Decodes a TripDescriptor message from the specified reader or buffer.
      * @param reader Reader or buffer to decode from
      * @param [length] Message length if known beforehand
-     * @returns TripDescriptor
+     * @returns {transit_realtime.TripDescriptor & transit_realtime.TripDescriptor.$Shape} TripDescriptor
      * @throws {Error} If the payload is not a reader or valid buffer
      * @throws {$protobuf.util.ProtocolError} If required fields are missing
      */
-    public static decode(
+    static decode(
       reader: $protobuf.Reader | Uint8Array,
       length?: number
-    ): transit_realtime.TripDescriptor;
+    ): transit_realtime.TripDescriptor & transit_realtime.TripDescriptor.$Shape;
 
     /**
      * Decodes a TripDescriptor message from the specified reader or buffer, length delimited.
      * @param reader Reader or buffer to decode from
-     * @returns TripDescriptor
+     * @returns {transit_realtime.TripDescriptor & transit_realtime.TripDescriptor.$Shape} TripDescriptor
      * @throws {Error} If the payload is not a reader or valid buffer
      * @throws {$protobuf.util.ProtocolError} If required fields are missing
      */
-    public static decodeDelimited(
+    static decodeDelimited(
       reader: $protobuf.Reader | Uint8Array
-    ): transit_realtime.TripDescriptor;
+    ): transit_realtime.TripDescriptor & transit_realtime.TripDescriptor.$Shape;
 
     /**
      * Verifies a TripDescriptor message.
      * @param message Plain object to verify
      * @returns `null` if valid, otherwise the reason why it is not
      */
-    public static verify(message: { [k: string]: any }): string | null;
+    static verify(message: { [k: string]: any }): string | null;
 
     /**
      * Creates a TripDescriptor message from a plain object. Also converts values to their respective internal types.
      * @param object Plain object
      * @returns TripDescriptor
      */
-    public static fromObject(object: {
+    static fromObject(object: {
       [k: string]: any;
     }): transit_realtime.TripDescriptor;
 
@@ -1551,7 +1821,7 @@ export namespace transit_realtime {
      * @param [options] Conversion options
      * @returns Plain object
      */
-    public static toObject(
+    static toObject(
       message: transit_realtime.TripDescriptor,
       options?: $protobuf.IConversionOptions
     ): { [k: string]: any };
@@ -1560,62 +1830,98 @@ export namespace transit_realtime {
      * Converts this TripDescriptor to JSON.
      * @returns JSON object
      */
-    public toJSON(): { [k: string]: any };
+    toJSON(): { [k: string]: any };
 
     /**
-     * Gets the default type url for TripDescriptor
-     * @param [typeUrlPrefix] your custom typeUrlPrefix(default "type.googleapis.com")
-     * @returns The default type url
+     * Gets the type url for TripDescriptor
+     * @param [prefix] Custom type url prefix, defaults to `"type.googleapis.com"`
+     * @returns The type url
      */
-    public static getTypeUrl(typeUrlPrefix?: string): string;
+    static getTypeUrl(prefix?: string): string;
   }
 
   namespace TripDescriptor {
+    /** Properties of a TripDescriptor. */
+    interface $Properties {
+      /** TripDescriptor tripId */
+      tripId?: string | null;
+
+      /** TripDescriptor routeId */
+      routeId?: string | null;
+
+      /** TripDescriptor directionId */
+      directionId?: number | null;
+
+      /** TripDescriptor startTime */
+      startTime?: string | null;
+
+      /** TripDescriptor startDate */
+      startDate?: string | null;
+
+      /** TripDescriptor scheduleRelationship */
+      scheduleRelationship?: transit_realtime.TripDescriptor.ScheduleRelationship | null;
+
+      /** Unknown fields preserved while decoding */
+      $unknowns?: Uint8Array[];
+    }
+
+    /** Shape of a TripDescriptor. */
+    type $Shape = transit_realtime.TripDescriptor.$Properties;
+
     /** ScheduleRelationship enum. */
     enum ScheduleRelationship {
+      /** SCHEDULED value */
       SCHEDULED = 0,
+
+      /** ADDED value */
       ADDED = 1,
+
+      /** UNSCHEDULED value */
       UNSCHEDULED = 2,
+
+      /** CANCELED value */
       CANCELED = 3,
     }
   }
 
-  /** Properties of a VehicleDescriptor. */
-  interface IVehicleDescriptor {
-    /** VehicleDescriptor id */
-    id?: string | null;
-
-    /** VehicleDescriptor label */
-    label?: string | null;
-
-    /** VehicleDescriptor licensePlate */
-    licensePlate?: string | null;
-  }
+  /**
+   * Properties of a VehicleDescriptor.
+   * @deprecated Use transit_realtime.VehicleDescriptor.$Properties instead.
+   */
+  interface IVehicleDescriptor
+    extends transit_realtime.VehicleDescriptor.$Properties {}
 
   /** Represents a VehicleDescriptor. */
-  class VehicleDescriptor implements IVehicleDescriptor {
+  class VehicleDescriptor {
     /**
      * Constructs a new VehicleDescriptor.
      * @param [properties] Properties to set
      */
-    constructor(properties?: transit_realtime.IVehicleDescriptor);
+    constructor(properties?: transit_realtime.VehicleDescriptor.$Properties);
+
+    /** Unknown fields preserved while decoding */
+    $unknowns?: Uint8Array[];
 
     /** VehicleDescriptor id. */
-    public id: string;
+    id: string;
 
     /** VehicleDescriptor label. */
-    public label: string;
+    label: string;
 
     /** VehicleDescriptor licensePlate. */
-    public licensePlate: string;
+    licensePlate: string;
 
     /**
      * Creates a new VehicleDescriptor instance using the specified properties.
      * @param [properties] Properties to set
      * @returns VehicleDescriptor instance
      */
-    public static create(
-      properties?: transit_realtime.IVehicleDescriptor
+    static create(
+      properties: transit_realtime.VehicleDescriptor.$Shape
+    ): transit_realtime.VehicleDescriptor &
+      transit_realtime.VehicleDescriptor.$Shape;
+    static create(
+      properties?: transit_realtime.VehicleDescriptor.$Properties
     ): transit_realtime.VehicleDescriptor;
 
     /**
@@ -1624,8 +1930,8 @@ export namespace transit_realtime {
      * @param [writer] Writer to encode to
      * @returns Writer
      */
-    public static encode(
-      message: transit_realtime.IVehicleDescriptor,
+    static encode(
+      message: transit_realtime.VehicleDescriptor.$Properties,
       writer?: $protobuf.Writer
     ): $protobuf.Writer;
 
@@ -1635,8 +1941,8 @@ export namespace transit_realtime {
      * @param [writer] Writer to encode to
      * @returns Writer
      */
-    public static encodeDelimited(
-      message: transit_realtime.IVehicleDescriptor,
+    static encodeDelimited(
+      message: transit_realtime.VehicleDescriptor.$Properties,
       writer?: $protobuf.Writer
     ): $protobuf.Writer;
 
@@ -1644,39 +1950,41 @@ export namespace transit_realtime {
      * Decodes a VehicleDescriptor message from the specified reader or buffer.
      * @param reader Reader or buffer to decode from
      * @param [length] Message length if known beforehand
-     * @returns VehicleDescriptor
+     * @returns {transit_realtime.VehicleDescriptor & transit_realtime.VehicleDescriptor.$Shape} VehicleDescriptor
      * @throws {Error} If the payload is not a reader or valid buffer
      * @throws {$protobuf.util.ProtocolError} If required fields are missing
      */
-    public static decode(
+    static decode(
       reader: $protobuf.Reader | Uint8Array,
       length?: number
-    ): transit_realtime.VehicleDescriptor;
+    ): transit_realtime.VehicleDescriptor &
+      transit_realtime.VehicleDescriptor.$Shape;
 
     /**
      * Decodes a VehicleDescriptor message from the specified reader or buffer, length delimited.
      * @param reader Reader or buffer to decode from
-     * @returns VehicleDescriptor
+     * @returns {transit_realtime.VehicleDescriptor & transit_realtime.VehicleDescriptor.$Shape} VehicleDescriptor
      * @throws {Error} If the payload is not a reader or valid buffer
      * @throws {$protobuf.util.ProtocolError} If required fields are missing
      */
-    public static decodeDelimited(
+    static decodeDelimited(
       reader: $protobuf.Reader | Uint8Array
-    ): transit_realtime.VehicleDescriptor;
+    ): transit_realtime.VehicleDescriptor &
+      transit_realtime.VehicleDescriptor.$Shape;
 
     /**
      * Verifies a VehicleDescriptor message.
      * @param message Plain object to verify
      * @returns `null` if valid, otherwise the reason why it is not
      */
-    public static verify(message: { [k: string]: any }): string | null;
+    static verify(message: { [k: string]: any }): string | null;
 
     /**
      * Creates a VehicleDescriptor message from a plain object. Also converts values to their respective internal types.
      * @param object Plain object
      * @returns VehicleDescriptor
      */
-    public static fromObject(object: {
+    static fromObject(object: {
       [k: string]: any;
     }): transit_realtime.VehicleDescriptor;
 
@@ -1686,7 +1994,7 @@ export namespace transit_realtime {
      * @param [options] Conversion options
      * @returns Plain object
      */
-    public static toObject(
+    static toObject(
       message: transit_realtime.VehicleDescriptor,
       options?: $protobuf.IConversionOptions
     ): { [k: string]: any };
@@ -1695,64 +2003,79 @@ export namespace transit_realtime {
      * Converts this VehicleDescriptor to JSON.
      * @returns JSON object
      */
-    public toJSON(): { [k: string]: any };
+    toJSON(): { [k: string]: any };
 
     /**
-     * Gets the default type url for VehicleDescriptor
-     * @param [typeUrlPrefix] your custom typeUrlPrefix(default "type.googleapis.com")
-     * @returns The default type url
+     * Gets the type url for VehicleDescriptor
+     * @param [prefix] Custom type url prefix, defaults to `"type.googleapis.com"`
+     * @returns The type url
      */
-    public static getTypeUrl(typeUrlPrefix?: string): string;
+    static getTypeUrl(prefix?: string): string;
   }
 
-  /** Properties of an EntitySelector. */
-  interface IEntitySelector {
-    /** EntitySelector agencyId */
-    agencyId?: string | null;
+  namespace VehicleDescriptor {
+    /** Properties of a VehicleDescriptor. */
+    interface $Properties {
+      /** VehicleDescriptor id */
+      id?: string | null;
 
-    /** EntitySelector routeId */
-    routeId?: string | null;
+      /** VehicleDescriptor label */
+      label?: string | null;
 
-    /** EntitySelector routeType */
-    routeType?: number | null;
+      /** VehicleDescriptor licensePlate */
+      licensePlate?: string | null;
 
-    /** EntitySelector trip */
-    trip?: transit_realtime.ITripDescriptor | null;
+      /** Unknown fields preserved while decoding */
+      $unknowns?: Uint8Array[];
+    }
 
-    /** EntitySelector stopId */
-    stopId?: string | null;
+    /** Shape of a VehicleDescriptor. */
+    type $Shape = transit_realtime.VehicleDescriptor.$Properties;
   }
+
+  /**
+   * Properties of an EntitySelector.
+   * @deprecated Use transit_realtime.EntitySelector.$Properties instead.
+   */
+  interface IEntitySelector
+    extends transit_realtime.EntitySelector.$Properties {}
 
   /** Represents an EntitySelector. */
-  class EntitySelector implements IEntitySelector {
+  class EntitySelector {
     /**
      * Constructs a new EntitySelector.
      * @param [properties] Properties to set
      */
-    constructor(properties?: transit_realtime.IEntitySelector);
+    constructor(properties?: transit_realtime.EntitySelector.$Properties);
+
+    /** Unknown fields preserved while decoding */
+    $unknowns?: Uint8Array[];
 
     /** EntitySelector agencyId. */
-    public agencyId: string;
+    agencyId: string;
 
     /** EntitySelector routeId. */
-    public routeId: string;
+    routeId: string;
 
     /** EntitySelector routeType. */
-    public routeType: number;
+    routeType: number;
 
     /** EntitySelector trip. */
-    public trip?: transit_realtime.ITripDescriptor | null;
+    trip?: transit_realtime.TripDescriptor.$Properties | null;
 
     /** EntitySelector stopId. */
-    public stopId: string;
+    stopId: string;
 
     /**
      * Creates a new EntitySelector instance using the specified properties.
      * @param [properties] Properties to set
      * @returns EntitySelector instance
      */
-    public static create(
-      properties?: transit_realtime.IEntitySelector
+    static create(
+      properties: transit_realtime.EntitySelector.$Shape
+    ): transit_realtime.EntitySelector & transit_realtime.EntitySelector.$Shape;
+    static create(
+      properties?: transit_realtime.EntitySelector.$Properties
     ): transit_realtime.EntitySelector;
 
     /**
@@ -1761,8 +2084,8 @@ export namespace transit_realtime {
      * @param [writer] Writer to encode to
      * @returns Writer
      */
-    public static encode(
-      message: transit_realtime.IEntitySelector,
+    static encode(
+      message: transit_realtime.EntitySelector.$Properties,
       writer?: $protobuf.Writer
     ): $protobuf.Writer;
 
@@ -1772,8 +2095,8 @@ export namespace transit_realtime {
      * @param [writer] Writer to encode to
      * @returns Writer
      */
-    public static encodeDelimited(
-      message: transit_realtime.IEntitySelector,
+    static encodeDelimited(
+      message: transit_realtime.EntitySelector.$Properties,
       writer?: $protobuf.Writer
     ): $protobuf.Writer;
 
@@ -1781,39 +2104,39 @@ export namespace transit_realtime {
      * Decodes an EntitySelector message from the specified reader or buffer.
      * @param reader Reader or buffer to decode from
      * @param [length] Message length if known beforehand
-     * @returns EntitySelector
+     * @returns {transit_realtime.EntitySelector & transit_realtime.EntitySelector.$Shape} EntitySelector
      * @throws {Error} If the payload is not a reader or valid buffer
      * @throws {$protobuf.util.ProtocolError} If required fields are missing
      */
-    public static decode(
+    static decode(
       reader: $protobuf.Reader | Uint8Array,
       length?: number
-    ): transit_realtime.EntitySelector;
+    ): transit_realtime.EntitySelector & transit_realtime.EntitySelector.$Shape;
 
     /**
      * Decodes an EntitySelector message from the specified reader or buffer, length delimited.
      * @param reader Reader or buffer to decode from
-     * @returns EntitySelector
+     * @returns {transit_realtime.EntitySelector & transit_realtime.EntitySelector.$Shape} EntitySelector
      * @throws {Error} If the payload is not a reader or valid buffer
      * @throws {$protobuf.util.ProtocolError} If required fields are missing
      */
-    public static decodeDelimited(
+    static decodeDelimited(
       reader: $protobuf.Reader | Uint8Array
-    ): transit_realtime.EntitySelector;
+    ): transit_realtime.EntitySelector & transit_realtime.EntitySelector.$Shape;
 
     /**
      * Verifies an EntitySelector message.
      * @param message Plain object to verify
      * @returns `null` if valid, otherwise the reason why it is not
      */
-    public static verify(message: { [k: string]: any }): string | null;
+    static verify(message: { [k: string]: any }): string | null;
 
     /**
      * Creates an EntitySelector message from a plain object. Also converts values to their respective internal types.
      * @param object Plain object
      * @returns EntitySelector
      */
-    public static fromObject(object: {
+    static fromObject(object: {
       [k: string]: any;
     }): transit_realtime.EntitySelector;
 
@@ -1823,7 +2146,7 @@ export namespace transit_realtime {
      * @param [options] Conversion options
      * @returns Plain object
      */
-    public static toObject(
+    static toObject(
       message: transit_realtime.EntitySelector,
       options?: $protobuf.IConversionOptions
     ): { [k: string]: any };
@@ -1832,40 +2155,74 @@ export namespace transit_realtime {
      * Converts this EntitySelector to JSON.
      * @returns JSON object
      */
-    public toJSON(): { [k: string]: any };
+    toJSON(): { [k: string]: any };
 
     /**
-     * Gets the default type url for EntitySelector
-     * @param [typeUrlPrefix] your custom typeUrlPrefix(default "type.googleapis.com")
-     * @returns The default type url
+     * Gets the type url for EntitySelector
+     * @param [prefix] Custom type url prefix, defaults to `"type.googleapis.com"`
+     * @returns The type url
      */
-    public static getTypeUrl(typeUrlPrefix?: string): string;
+    static getTypeUrl(prefix?: string): string;
   }
 
-  /** Properties of a TranslatedString. */
-  interface ITranslatedString {
-    /** TranslatedString translation */
-    translation?: transit_realtime.TranslatedString.ITranslation[] | null;
+  namespace EntitySelector {
+    /** Properties of an EntitySelector. */
+    interface $Properties {
+      /** EntitySelector agencyId */
+      agencyId?: string | null;
+
+      /** EntitySelector routeId */
+      routeId?: string | null;
+
+      /** EntitySelector routeType */
+      routeType?: number | null;
+
+      /** EntitySelector trip */
+      trip?: transit_realtime.TripDescriptor.$Properties | null;
+
+      /** EntitySelector stopId */
+      stopId?: string | null;
+
+      /** Unknown fields preserved while decoding */
+      $unknowns?: Uint8Array[];
+    }
+
+    /** Shape of an EntitySelector. */
+    type $Shape = transit_realtime.EntitySelector.$Properties;
   }
+
+  /**
+   * Properties of a TranslatedString.
+   * @deprecated Use transit_realtime.TranslatedString.$Properties instead.
+   */
+  interface ITranslatedString
+    extends transit_realtime.TranslatedString.$Properties {}
 
   /** Represents a TranslatedString. */
-  class TranslatedString implements ITranslatedString {
+  class TranslatedString {
     /**
      * Constructs a new TranslatedString.
      * @param [properties] Properties to set
      */
-    constructor(properties?: transit_realtime.ITranslatedString);
+    constructor(properties?: transit_realtime.TranslatedString.$Properties);
+
+    /** Unknown fields preserved while decoding */
+    $unknowns?: Uint8Array[];
 
     /** TranslatedString translation. */
-    public translation: transit_realtime.TranslatedString.ITranslation[];
+    translation: transit_realtime.TranslatedString.Translation.$Properties[];
 
     /**
      * Creates a new TranslatedString instance using the specified properties.
      * @param [properties] Properties to set
      * @returns TranslatedString instance
      */
-    public static create(
-      properties?: transit_realtime.ITranslatedString
+    static create(
+      properties: transit_realtime.TranslatedString.$Shape
+    ): transit_realtime.TranslatedString &
+      transit_realtime.TranslatedString.$Shape;
+    static create(
+      properties?: transit_realtime.TranslatedString.$Properties
     ): transit_realtime.TranslatedString;
 
     /**
@@ -1874,8 +2231,8 @@ export namespace transit_realtime {
      * @param [writer] Writer to encode to
      * @returns Writer
      */
-    public static encode(
-      message: transit_realtime.ITranslatedString,
+    static encode(
+      message: transit_realtime.TranslatedString.$Properties,
       writer?: $protobuf.Writer
     ): $protobuf.Writer;
 
@@ -1885,8 +2242,8 @@ export namespace transit_realtime {
      * @param [writer] Writer to encode to
      * @returns Writer
      */
-    public static encodeDelimited(
-      message: transit_realtime.ITranslatedString,
+    static encodeDelimited(
+      message: transit_realtime.TranslatedString.$Properties,
       writer?: $protobuf.Writer
     ): $protobuf.Writer;
 
@@ -1894,39 +2251,41 @@ export namespace transit_realtime {
      * Decodes a TranslatedString message from the specified reader or buffer.
      * @param reader Reader or buffer to decode from
      * @param [length] Message length if known beforehand
-     * @returns TranslatedString
+     * @returns {transit_realtime.TranslatedString & transit_realtime.TranslatedString.$Shape} TranslatedString
      * @throws {Error} If the payload is not a reader or valid buffer
      * @throws {$protobuf.util.ProtocolError} If required fields are missing
      */
-    public static decode(
+    static decode(
       reader: $protobuf.Reader | Uint8Array,
       length?: number
-    ): transit_realtime.TranslatedString;
+    ): transit_realtime.TranslatedString &
+      transit_realtime.TranslatedString.$Shape;
 
     /**
      * Decodes a TranslatedString message from the specified reader or buffer, length delimited.
      * @param reader Reader or buffer to decode from
-     * @returns TranslatedString
+     * @returns {transit_realtime.TranslatedString & transit_realtime.TranslatedString.$Shape} TranslatedString
      * @throws {Error} If the payload is not a reader or valid buffer
      * @throws {$protobuf.util.ProtocolError} If required fields are missing
      */
-    public static decodeDelimited(
+    static decodeDelimited(
       reader: $protobuf.Reader | Uint8Array
-    ): transit_realtime.TranslatedString;
+    ): transit_realtime.TranslatedString &
+      transit_realtime.TranslatedString.$Shape;
 
     /**
      * Verifies a TranslatedString message.
      * @param message Plain object to verify
      * @returns `null` if valid, otherwise the reason why it is not
      */
-    public static verify(message: { [k: string]: any }): string | null;
+    static verify(message: { [k: string]: any }): string | null;
 
     /**
      * Creates a TranslatedString message from a plain object. Also converts values to their respective internal types.
      * @param object Plain object
      * @returns TranslatedString
      */
-    public static fromObject(object: {
+    static fromObject(object: {
       [k: string]: any;
     }): transit_realtime.TranslatedString;
 
@@ -1936,7 +2295,7 @@ export namespace transit_realtime {
      * @param [options] Conversion options
      * @returns Plain object
      */
-    public static toObject(
+    static toObject(
       message: transit_realtime.TranslatedString,
       options?: $protobuf.IConversionOptions
     ): { [k: string]: any };
@@ -1945,47 +2304,68 @@ export namespace transit_realtime {
      * Converts this TranslatedString to JSON.
      * @returns JSON object
      */
-    public toJSON(): { [k: string]: any };
+    toJSON(): { [k: string]: any };
 
     /**
-     * Gets the default type url for TranslatedString
-     * @param [typeUrlPrefix] your custom typeUrlPrefix(default "type.googleapis.com")
-     * @returns The default type url
+     * Gets the type url for TranslatedString
+     * @param [prefix] Custom type url prefix, defaults to `"type.googleapis.com"`
+     * @returns The type url
      */
-    public static getTypeUrl(typeUrlPrefix?: string): string;
+    static getTypeUrl(prefix?: string): string;
   }
 
   namespace TranslatedString {
-    /** Properties of a Translation. */
-    interface ITranslation {
-      /** Translation text */
-      text: string;
+    /** Properties of a TranslatedString. */
+    interface $Properties {
+      /** TranslatedString translation */
+      translation?:
+        | transit_realtime.TranslatedString.Translation.$Properties[]
+        | null;
 
-      /** Translation language */
-      language?: string | null;
+      /** Unknown fields preserved while decoding */
+      $unknowns?: Uint8Array[];
     }
 
+    /** Shape of a TranslatedString. */
+    type $Shape = transit_realtime.TranslatedString.$Properties;
+
+    /**
+     * Properties of a Translation.
+     * @deprecated Use transit_realtime.TranslatedString.Translation.$Properties instead.
+     */
+    interface ITranslation
+      extends transit_realtime.TranslatedString.Translation.$Properties {}
+
     /** Represents a Translation. */
-    class Translation implements ITranslation {
+    class Translation {
       /**
        * Constructs a new Translation.
        * @param [properties] Properties to set
        */
-      constructor(properties?: transit_realtime.TranslatedString.ITranslation);
+      constructor(
+        properties?: transit_realtime.TranslatedString.Translation.$Properties
+      );
+
+      /** Unknown fields preserved while decoding */
+      $unknowns?: Uint8Array[];
 
       /** Translation text. */
-      public text: string;
+      text: string;
 
       /** Translation language. */
-      public language: string;
+      language: string;
 
       /**
        * Creates a new Translation instance using the specified properties.
        * @param [properties] Properties to set
        * @returns Translation instance
        */
-      public static create(
-        properties?: transit_realtime.TranslatedString.ITranslation
+      static create(
+        properties: transit_realtime.TranslatedString.Translation.$Shape
+      ): transit_realtime.TranslatedString.Translation &
+        transit_realtime.TranslatedString.Translation.$Shape;
+      static create(
+        properties?: transit_realtime.TranslatedString.Translation.$Properties
       ): transit_realtime.TranslatedString.Translation;
 
       /**
@@ -1994,8 +2374,8 @@ export namespace transit_realtime {
        * @param [writer] Writer to encode to
        * @returns Writer
        */
-      public static encode(
-        message: transit_realtime.TranslatedString.ITranslation,
+      static encode(
+        message: transit_realtime.TranslatedString.Translation.$Properties,
         writer?: $protobuf.Writer
       ): $protobuf.Writer;
 
@@ -2005,8 +2385,8 @@ export namespace transit_realtime {
        * @param [writer] Writer to encode to
        * @returns Writer
        */
-      public static encodeDelimited(
-        message: transit_realtime.TranslatedString.ITranslation,
+      static encodeDelimited(
+        message: transit_realtime.TranslatedString.Translation.$Properties,
         writer?: $protobuf.Writer
       ): $protobuf.Writer;
 
@@ -2014,39 +2394,41 @@ export namespace transit_realtime {
        * Decodes a Translation message from the specified reader or buffer.
        * @param reader Reader or buffer to decode from
        * @param [length] Message length if known beforehand
-       * @returns Translation
+       * @returns {transit_realtime.TranslatedString.Translation & transit_realtime.TranslatedString.Translation.$Shape} Translation
        * @throws {Error} If the payload is not a reader or valid buffer
        * @throws {$protobuf.util.ProtocolError} If required fields are missing
        */
-      public static decode(
+      static decode(
         reader: $protobuf.Reader | Uint8Array,
         length?: number
-      ): transit_realtime.TranslatedString.Translation;
+      ): transit_realtime.TranslatedString.Translation &
+        transit_realtime.TranslatedString.Translation.$Shape;
 
       /**
        * Decodes a Translation message from the specified reader or buffer, length delimited.
        * @param reader Reader or buffer to decode from
-       * @returns Translation
+       * @returns {transit_realtime.TranslatedString.Translation & transit_realtime.TranslatedString.Translation.$Shape} Translation
        * @throws {Error} If the payload is not a reader or valid buffer
        * @throws {$protobuf.util.ProtocolError} If required fields are missing
        */
-      public static decodeDelimited(
+      static decodeDelimited(
         reader: $protobuf.Reader | Uint8Array
-      ): transit_realtime.TranslatedString.Translation;
+      ): transit_realtime.TranslatedString.Translation &
+        transit_realtime.TranslatedString.Translation.$Shape;
 
       /**
        * Verifies a Translation message.
        * @param message Plain object to verify
        * @returns `null` if valid, otherwise the reason why it is not
        */
-      public static verify(message: { [k: string]: any }): string | null;
+      static verify(message: { [k: string]: any }): string | null;
 
       /**
        * Creates a Translation message from a plain object. Also converts values to their respective internal types.
        * @param object Plain object
        * @returns Translation
        */
-      public static fromObject(object: {
+      static fromObject(object: {
         [k: string]: any;
       }): transit_realtime.TranslatedString.Translation;
 
@@ -2056,7 +2438,7 @@ export namespace transit_realtime {
        * @param [options] Conversion options
        * @returns Plain object
        */
-      public static toObject(
+      static toObject(
         message: transit_realtime.TranslatedString.Translation,
         options?: $protobuf.IConversionOptions
       ): { [k: string]: any };
@@ -2065,14 +2447,31 @@ export namespace transit_realtime {
        * Converts this Translation to JSON.
        * @returns JSON object
        */
-      public toJSON(): { [k: string]: any };
+      toJSON(): { [k: string]: any };
 
       /**
-       * Gets the default type url for Translation
-       * @param [typeUrlPrefix] your custom typeUrlPrefix(default "type.googleapis.com")
-       * @returns The default type url
+       * Gets the type url for Translation
+       * @param [prefix] Custom type url prefix, defaults to `"type.googleapis.com"`
+       * @returns The type url
        */
-      public static getTypeUrl(typeUrlPrefix?: string): string;
+      static getTypeUrl(prefix?: string): string;
+    }
+
+    namespace Translation {
+      /** Properties of a Translation. */
+      interface $Properties {
+        /** Translation text */
+        text: string;
+
+        /** Translation language */
+        language?: string | null;
+
+        /** Unknown fields preserved while decoding */
+        $unknowns?: Uint8Array[];
+      }
+
+      /** Shape of a Translation. */
+      type $Shape = transit_realtime.TranslatedString.Translation.$Properties;
     }
   }
 }

--- a/src/protobuf/gtfsRealtime.js
+++ b/src/protobuf/gtfsRealtime.js
@@ -1,5 +1,5 @@
-/*eslint-disable block-scoped-var, id-length, no-control-regex, no-magic-numbers, no-prototype-builtins, no-redeclare, no-shadow, no-var, sort-vars*/
-import * as $protobuf from "protobufjs/minimal";
+/*eslint-disable block-scoped-var, id-length, no-control-regex, no-magic-numbers, no-mixed-operators, no-prototype-builtins, no-redeclare, no-shadow, no-var, sort-vars, default-case, jsdoc/require-param*/
+import $protobuf from "protobufjs/minimal.js";
 
 // Common aliases
 const $Reader = $protobuf.Reader,
@@ -20,30 +20,44 @@ export const transit_realtime = ($root.transit_realtime = (() => {
   transit_realtime.FeedMessage = (function () {
     /**
      * Properties of a FeedMessage.
+     * @typedef {Object} transit_realtime.FeedMessage.$Properties
+     * @property {transit_realtime.FeedHeader.$Properties} header FeedMessage header
+     * @property {Array.<transit_realtime.FeedEntity.$Properties>|null} [entity] FeedMessage entity
+     * @property {Array.<Uint8Array>} [$unknowns] Unknown fields preserved while decoding
+     */
+
+    /**
+     * Properties of a FeedMessage.
      * @memberof transit_realtime
      * @interface IFeedMessage
-     * @property {transit_realtime.IFeedHeader} header FeedMessage header
-     * @property {Array.<transit_realtime.IFeedEntity>|null} [entity] FeedMessage entity
+     * @augments transit_realtime.FeedMessage.$Properties
+     * @deprecated Use transit_realtime.FeedMessage.$Properties instead.
+     */
+
+    /**
+     * Shape of a FeedMessage.
+     * @typedef {transit_realtime.FeedMessage.$Properties} transit_realtime.FeedMessage.$Shape
      */
 
     /**
      * Constructs a new FeedMessage.
      * @memberof transit_realtime
      * @classdesc Represents a FeedMessage.
-     * @implements IFeedMessage
      * @constructor
-     * @param {transit_realtime.IFeedMessage=} [properties] Properties to set
+     * @param {transit_realtime.FeedMessage.$Properties=} [properties] Properties to set
+     * @property {Array.<Uint8Array>} [$unknowns] Unknown fields preserved while decoding
      */
     function FeedMessage(properties) {
       this.entity = [];
       if (properties)
         for (let keys = Object.keys(properties), i = 0; i < keys.length; ++i)
-          if (properties[keys[i]] != null) this[keys[i]] = properties[keys[i]];
+          if (properties[keys[i]] != null && keys[i] !== "__proto__")
+            this[keys[i]] = properties[keys[i]];
     }
 
     /**
      * FeedMessage header.
-     * @member {transit_realtime.IFeedHeader} header
+     * @member {transit_realtime.FeedHeader.$Properties} header
      * @memberof transit_realtime.FeedMessage
      * @instance
      */
@@ -51,7 +65,7 @@ export const transit_realtime = ($root.transit_realtime = (() => {
 
     /**
      * FeedMessage entity.
-     * @member {Array.<transit_realtime.IFeedEntity>} entity
+     * @member {Array.<transit_realtime.FeedEntity.$Properties>} entity
      * @memberof transit_realtime.FeedMessage
      * @instance
      */
@@ -62,8 +76,12 @@ export const transit_realtime = ($root.transit_realtime = (() => {
      * @function create
      * @memberof transit_realtime.FeedMessage
      * @static
-     * @param {transit_realtime.IFeedMessage=} [properties] Properties to set
+     * @param {transit_realtime.FeedMessage.$Properties=} [properties] Properties to set
      * @returns {transit_realtime.FeedMessage} FeedMessage instance
+     * @type {{
+     *   (properties: transit_realtime.FeedMessage.$Shape): transit_realtime.FeedMessage & transit_realtime.FeedMessage.$Shape;
+     *   (properties?: transit_realtime.FeedMessage.$Properties): transit_realtime.FeedMessage;
+     * }}
      */
     FeedMessage.create = function create(properties) {
       return new FeedMessage(properties);
@@ -74,22 +92,32 @@ export const transit_realtime = ($root.transit_realtime = (() => {
      * @function encode
      * @memberof transit_realtime.FeedMessage
      * @static
-     * @param {transit_realtime.IFeedMessage} message FeedMessage message or plain object to encode
+     * @param {transit_realtime.FeedMessage.$Properties} message FeedMessage message or plain object to encode
      * @param {$protobuf.Writer} [writer] Writer to encode to
      * @returns {$protobuf.Writer} Writer
      */
-    FeedMessage.encode = function encode(message, writer) {
+    FeedMessage.encode = function encode(message, writer, _depth) {
       if (!writer) writer = $Writer.create();
+      if (_depth === undefined) _depth = 0;
+      if (_depth > $util.recursionLimit) throw Error("max depth exceeded");
       $root.transit_realtime.FeedHeader.encode(
         message.header,
-        writer.uint32(/* id 1, wireType 2 =*/ 10).fork()
+        writer.uint32(/* id 1, wireType 2 =*/ 10).fork(),
+        _depth + 1
       ).ldelim();
       if (message.entity != null && message.entity.length)
         for (let i = 0; i < message.entity.length; ++i)
           $root.transit_realtime.FeedEntity.encode(
             message.entity[i],
-            writer.uint32(/* id 2, wireType 2 =*/ 18).fork()
+            writer.uint32(/* id 2, wireType 2 =*/ 18).fork(),
+            _depth + 1
           ).ldelim();
+      if (
+        message.$unknowns != null &&
+        Object.hasOwnProperty.call(message, "$unknowns")
+      )
+        for (let i = 0; i < message.$unknowns.length; ++i)
+          writer.raw(message.$unknowns[i]);
       return writer;
     };
 
@@ -98,12 +126,15 @@ export const transit_realtime = ($root.transit_realtime = (() => {
      * @function encodeDelimited
      * @memberof transit_realtime.FeedMessage
      * @static
-     * @param {transit_realtime.IFeedMessage} message FeedMessage message or plain object to encode
+     * @param {transit_realtime.FeedMessage.$Properties} message FeedMessage message or plain object to encode
      * @param {$protobuf.Writer} [writer] Writer to encode to
      * @returns {$protobuf.Writer} Writer
      */
     FeedMessage.encodeDelimited = function encodeDelimited(message, writer) {
-      return this.encode(message, writer).ldelim();
+      return this.encode(
+        message,
+        writer && writer.len ? writer.fork() : writer
+      ).ldelim();
     };
 
     /**
@@ -113,37 +144,65 @@ export const transit_realtime = ($root.transit_realtime = (() => {
      * @static
      * @param {$protobuf.Reader|Uint8Array} reader Reader or buffer to decode from
      * @param {number} [length] Message length if known beforehand
-     * @returns {transit_realtime.FeedMessage} FeedMessage
+     * @returns {transit_realtime.FeedMessage & transit_realtime.FeedMessage.$Shape} FeedMessage
      * @throws {Error} If the payload is not a reader or valid buffer
      * @throws {$protobuf.util.ProtocolError} If required fields are missing
      */
-    FeedMessage.decode = function decode(reader, length, error) {
+    FeedMessage.decode = function decode(
+      reader,
+      length,
+      _end,
+      _depth,
+      _target
+    ) {
       if (!(reader instanceof $Reader)) reader = $Reader.create(reader);
+      if (_depth === undefined) _depth = 0;
+      if (_depth > $Reader.recursionLimit) throw Error("max depth exceeded");
       let end = length === undefined ? reader.len : reader.pos + length,
-        message = new $root.transit_realtime.FeedMessage();
+        message = _target || new $root.transit_realtime.FeedMessage();
       while (reader.pos < end) {
-        let tag = reader.uint32();
-        if (tag === error) break;
-        switch (tag >>> 3) {
+        let start = reader.pos;
+        let tag = reader.tag();
+        if (tag === _end) {
+          _end = undefined;
+          break;
+        }
+        let wireType = tag & 7;
+        switch ((tag >>>= 3)) {
           case 1: {
+            if (wireType !== 2) break;
             message.header = $root.transit_realtime.FeedHeader.decode(
               reader,
-              reader.uint32()
+              reader.uint32(),
+              undefined,
+              _depth + 1,
+              message.header
             );
-            break;
+            continue;
           }
           case 2: {
+            if (wireType !== 2) break;
             if (!(message.entity && message.entity.length)) message.entity = [];
             message.entity.push(
-              $root.transit_realtime.FeedEntity.decode(reader, reader.uint32())
+              $root.transit_realtime.FeedEntity.decode(
+                reader,
+                reader.uint32(),
+                undefined,
+                _depth + 1
+              )
             );
-            break;
+            continue;
           }
-          default:
-            reader.skipType(tag & 7);
-            break;
+        }
+        reader.skipType(wireType, _depth, tag);
+        if (!reader.discardUnknown) {
+          $util.makeProp(message, "$unknowns", false);
+          (message.$unknowns || (message.$unknowns = [])).push(
+            reader.raw(start, reader.pos)
+          );
         }
       }
+      if (_end !== undefined) throw Error("missing end group");
       if (!message.hasOwnProperty("header"))
         throw $util.ProtocolError("missing required 'header'", {
           instance: message,
@@ -157,7 +216,7 @@ export const transit_realtime = ($root.transit_realtime = (() => {
      * @memberof transit_realtime.FeedMessage
      * @static
      * @param {$protobuf.Reader|Uint8Array} reader Reader or buffer to decode from
-     * @returns {transit_realtime.FeedMessage} FeedMessage
+     * @returns {transit_realtime.FeedMessage & transit_realtime.FeedMessage.$Shape} FeedMessage
      * @throws {Error} If the payload is not a reader or valid buffer
      * @throws {$protobuf.util.ProtocolError} If required fields are missing
      */
@@ -174,18 +233,24 @@ export const transit_realtime = ($root.transit_realtime = (() => {
      * @param {Object.<string,*>} message Plain object to verify
      * @returns {string|null} `null` if valid, otherwise the reason why it is not
      */
-    FeedMessage.verify = function verify(message) {
+    FeedMessage.verify = function verify(message, _depth) {
       if (typeof message !== "object" || message === null)
         return "object expected";
+      if (_depth === undefined) _depth = 0;
+      if (_depth > $util.recursionLimit) return "max depth exceeded";
       {
-        let error = $root.transit_realtime.FeedHeader.verify(message.header);
+        let error = $root.transit_realtime.FeedHeader.verify(
+          message.header,
+          _depth + 1
+        );
         if (error) return "header." + error;
       }
       if (message.entity != null && message.hasOwnProperty("entity")) {
         if (!Array.isArray(message.entity)) return "entity: array expected";
         for (let i = 0; i < message.entity.length; ++i) {
           let error = $root.transit_realtime.FeedEntity.verify(
-            message.entity[i]
+            message.entity[i],
+            _depth + 1
           );
           if (error) return "entity." + error;
         }
@@ -201,16 +266,21 @@ export const transit_realtime = ($root.transit_realtime = (() => {
      * @param {Object.<string,*>} object Plain object
      * @returns {transit_realtime.FeedMessage} FeedMessage
      */
-    FeedMessage.fromObject = function fromObject(object) {
+    FeedMessage.fromObject = function fromObject(object, _depth) {
       if (object instanceof $root.transit_realtime.FeedMessage) return object;
+      if (!$util.isObject(object))
+        throw TypeError(".transit_realtime.FeedMessage: object expected");
+      if (_depth === undefined) _depth = 0;
+      if (_depth > $util.recursionLimit) throw Error("max depth exceeded");
       let message = new $root.transit_realtime.FeedMessage();
       if (object.header != null) {
-        if (typeof object.header !== "object")
+        if (!$util.isObject(object.header))
           throw TypeError(
             ".transit_realtime.FeedMessage.header: object expected"
           );
         message.header = $root.transit_realtime.FeedHeader.fromObject(
-          object.header
+          object.header,
+          _depth + 1
         );
       }
       if (object.entity) {
@@ -218,14 +288,15 @@ export const transit_realtime = ($root.transit_realtime = (() => {
           throw TypeError(
             ".transit_realtime.FeedMessage.entity: array expected"
           );
-        message.entity = [];
+        message.entity = Array(object.entity.length);
         for (let i = 0; i < object.entity.length; ++i) {
-          if (typeof object.entity[i] !== "object")
+          if (!$util.isObject(object.entity[i]))
             throw TypeError(
               ".transit_realtime.FeedMessage.entity: object expected"
             );
           message.entity[i] = $root.transit_realtime.FeedEntity.fromObject(
-            object.entity[i]
+            object.entity[i],
+            _depth + 1
           );
         }
       }
@@ -241,22 +312,26 @@ export const transit_realtime = ($root.transit_realtime = (() => {
      * @param {$protobuf.IConversionOptions} [options] Conversion options
      * @returns {Object.<string,*>} Plain object
      */
-    FeedMessage.toObject = function toObject(message, options) {
+    FeedMessage.toObject = function toObject(message, options, _depth) {
       if (!options) options = {};
+      if (_depth === undefined) _depth = 0;
+      if (_depth > $util.recursionLimit) throw Error("max depth exceeded");
       let object = {};
       if (options.arrays || options.defaults) object.entity = [];
       if (options.defaults) object.header = null;
       if (message.header != null && message.hasOwnProperty("header"))
         object.header = $root.transit_realtime.FeedHeader.toObject(
           message.header,
-          options
+          options,
+          _depth + 1
         );
       if (message.entity && message.entity.length) {
-        object.entity = [];
+        object.entity = Array(message.entity.length);
         for (let j = 0; j < message.entity.length; ++j)
           object.entity[j] = $root.transit_realtime.FeedEntity.toObject(
             message.entity[j],
-            options
+            options,
+            _depth + 1
           );
       }
       return object;
@@ -274,18 +349,16 @@ export const transit_realtime = ($root.transit_realtime = (() => {
     };
 
     /**
-     * Gets the default type url for FeedMessage
+     * Gets the type url for FeedMessage
      * @function getTypeUrl
      * @memberof transit_realtime.FeedMessage
      * @static
-     * @param {string} [typeUrlPrefix] your custom typeUrlPrefix(default "type.googleapis.com")
-     * @returns {string} The default type url
+     * @param {string} [prefix] Custom type url prefix, defaults to `"type.googleapis.com"`
+     * @returns {string} The type url
      */
-    FeedMessage.getTypeUrl = function getTypeUrl(typeUrlPrefix) {
-      if (typeUrlPrefix === undefined) {
-        typeUrlPrefix = "type.googleapis.com";
-      }
-      return typeUrlPrefix + "/transit_realtime.FeedMessage";
+    FeedMessage.getTypeUrl = function getTypeUrl(prefix) {
+      if (prefix === undefined) prefix = "type.googleapis.com";
+      return prefix + "/transit_realtime.FeedMessage";
     };
 
     return FeedMessage;
@@ -294,25 +367,39 @@ export const transit_realtime = ($root.transit_realtime = (() => {
   transit_realtime.FeedHeader = (function () {
     /**
      * Properties of a FeedHeader.
-     * @memberof transit_realtime
-     * @interface IFeedHeader
+     * @typedef {Object} transit_realtime.FeedHeader.$Properties
      * @property {string} gtfsRealtimeVersion FeedHeader gtfsRealtimeVersion
      * @property {transit_realtime.FeedHeader.Incrementality|null} [incrementality] FeedHeader incrementality
      * @property {number|Long|null} [timestamp] FeedHeader timestamp
+     * @property {Array.<Uint8Array>} [$unknowns] Unknown fields preserved while decoding
+     */
+
+    /**
+     * Properties of a FeedHeader.
+     * @memberof transit_realtime
+     * @interface IFeedHeader
+     * @augments transit_realtime.FeedHeader.$Properties
+     * @deprecated Use transit_realtime.FeedHeader.$Properties instead.
+     */
+
+    /**
+     * Shape of a FeedHeader.
+     * @typedef {transit_realtime.FeedHeader.$Properties} transit_realtime.FeedHeader.$Shape
      */
 
     /**
      * Constructs a new FeedHeader.
      * @memberof transit_realtime
      * @classdesc Represents a FeedHeader.
-     * @implements IFeedHeader
      * @constructor
-     * @param {transit_realtime.IFeedHeader=} [properties] Properties to set
+     * @param {transit_realtime.FeedHeader.$Properties=} [properties] Properties to set
+     * @property {Array.<Uint8Array>} [$unknowns] Unknown fields preserved while decoding
      */
     function FeedHeader(properties) {
       if (properties)
         for (let keys = Object.keys(properties), i = 0; i < keys.length; ++i)
-          if (properties[keys[i]] != null) this[keys[i]] = properties[keys[i]];
+          if (properties[keys[i]] != null && keys[i] !== "__proto__")
+            this[keys[i]] = properties[keys[i]];
     }
 
     /**
@@ -346,8 +433,12 @@ export const transit_realtime = ($root.transit_realtime = (() => {
      * @function create
      * @memberof transit_realtime.FeedHeader
      * @static
-     * @param {transit_realtime.IFeedHeader=} [properties] Properties to set
+     * @param {transit_realtime.FeedHeader.$Properties=} [properties] Properties to set
      * @returns {transit_realtime.FeedHeader} FeedHeader instance
+     * @type {{
+     *   (properties: transit_realtime.FeedHeader.$Shape): transit_realtime.FeedHeader & transit_realtime.FeedHeader.$Shape;
+     *   (properties?: transit_realtime.FeedHeader.$Properties): transit_realtime.FeedHeader;
+     * }}
      */
     FeedHeader.create = function create(properties) {
       return new FeedHeader(properties);
@@ -358,12 +449,14 @@ export const transit_realtime = ($root.transit_realtime = (() => {
      * @function encode
      * @memberof transit_realtime.FeedHeader
      * @static
-     * @param {transit_realtime.IFeedHeader} message FeedHeader message or plain object to encode
+     * @param {transit_realtime.FeedHeader.$Properties} message FeedHeader message or plain object to encode
      * @param {$protobuf.Writer} [writer] Writer to encode to
      * @returns {$protobuf.Writer} Writer
      */
-    FeedHeader.encode = function encode(message, writer) {
+    FeedHeader.encode = function encode(message, writer, _depth) {
       if (!writer) writer = $Writer.create();
+      if (_depth === undefined) _depth = 0;
+      if (_depth > $util.recursionLimit) throw Error("max depth exceeded");
       writer
         .uint32(/* id 1, wireType 2 =*/ 10)
         .string(message.gtfsRealtimeVersion);
@@ -377,6 +470,12 @@ export const transit_realtime = ($root.transit_realtime = (() => {
         Object.hasOwnProperty.call(message, "timestamp")
       )
         writer.uint32(/* id 3, wireType 0 =*/ 24).uint64(message.timestamp);
+      if (
+        message.$unknowns != null &&
+        Object.hasOwnProperty.call(message, "$unknowns")
+      )
+        for (let i = 0; i < message.$unknowns.length; ++i)
+          writer.raw(message.$unknowns[i]);
       return writer;
     };
 
@@ -385,12 +484,15 @@ export const transit_realtime = ($root.transit_realtime = (() => {
      * @function encodeDelimited
      * @memberof transit_realtime.FeedHeader
      * @static
-     * @param {transit_realtime.IFeedHeader} message FeedHeader message or plain object to encode
+     * @param {transit_realtime.FeedHeader.$Properties} message FeedHeader message or plain object to encode
      * @param {$protobuf.Writer} [writer] Writer to encode to
      * @returns {$protobuf.Writer} Writer
      */
     FeedHeader.encodeDelimited = function encodeDelimited(message, writer) {
-      return this.encode(message, writer).ldelim();
+      return this.encode(
+        message,
+        writer && writer.len ? writer.fork() : writer
+      ).ldelim();
     };
 
     /**
@@ -400,35 +502,50 @@ export const transit_realtime = ($root.transit_realtime = (() => {
      * @static
      * @param {$protobuf.Reader|Uint8Array} reader Reader or buffer to decode from
      * @param {number} [length] Message length if known beforehand
-     * @returns {transit_realtime.FeedHeader} FeedHeader
+     * @returns {transit_realtime.FeedHeader & transit_realtime.FeedHeader.$Shape} FeedHeader
      * @throws {Error} If the payload is not a reader or valid buffer
      * @throws {$protobuf.util.ProtocolError} If required fields are missing
      */
-    FeedHeader.decode = function decode(reader, length, error) {
+    FeedHeader.decode = function decode(reader, length, _end, _depth, _target) {
       if (!(reader instanceof $Reader)) reader = $Reader.create(reader);
+      if (_depth === undefined) _depth = 0;
+      if (_depth > $Reader.recursionLimit) throw Error("max depth exceeded");
       let end = length === undefined ? reader.len : reader.pos + length,
-        message = new $root.transit_realtime.FeedHeader();
+        message = _target || new $root.transit_realtime.FeedHeader();
       while (reader.pos < end) {
-        let tag = reader.uint32();
-        if (tag === error) break;
-        switch (tag >>> 3) {
+        let start = reader.pos;
+        let tag = reader.tag();
+        if (tag === _end) {
+          _end = undefined;
+          break;
+        }
+        let wireType = tag & 7;
+        switch ((tag >>>= 3)) {
           case 1: {
+            if (wireType !== 2) break;
             message.gtfsRealtimeVersion = reader.string();
-            break;
+            continue;
           }
           case 2: {
+            if (wireType !== 0) break;
             message.incrementality = reader.int32();
-            break;
+            continue;
           }
           case 3: {
+            if (wireType !== 0) break;
             message.timestamp = reader.uint64();
-            break;
+            continue;
           }
-          default:
-            reader.skipType(tag & 7);
-            break;
+        }
+        reader.skipType(wireType, _depth, tag);
+        if (!reader.discardUnknown) {
+          $util.makeProp(message, "$unknowns", false);
+          (message.$unknowns || (message.$unknowns = [])).push(
+            reader.raw(start, reader.pos)
+          );
         }
       }
+      if (_end !== undefined) throw Error("missing end group");
       if (!message.hasOwnProperty("gtfsRealtimeVersion"))
         throw $util.ProtocolError("missing required 'gtfsRealtimeVersion'", {
           instance: message,
@@ -442,7 +559,7 @@ export const transit_realtime = ($root.transit_realtime = (() => {
      * @memberof transit_realtime.FeedHeader
      * @static
      * @param {$protobuf.Reader|Uint8Array} reader Reader or buffer to decode from
-     * @returns {transit_realtime.FeedHeader} FeedHeader
+     * @returns {transit_realtime.FeedHeader & transit_realtime.FeedHeader.$Shape} FeedHeader
      * @throws {Error} If the payload is not a reader or valid buffer
      * @throws {$protobuf.util.ProtocolError} If required fields are missing
      */
@@ -459,9 +576,11 @@ export const transit_realtime = ($root.transit_realtime = (() => {
      * @param {Object.<string,*>} message Plain object to verify
      * @returns {string|null} `null` if valid, otherwise the reason why it is not
      */
-    FeedHeader.verify = function verify(message) {
+    FeedHeader.verify = function verify(message, _depth) {
       if (typeof message !== "object" || message === null)
         return "object expected";
+      if (_depth === undefined) _depth = 0;
+      if (_depth > $util.recursionLimit) return "max depth exceeded";
       if (!$util.isString(message.gtfsRealtimeVersion))
         return "gtfsRealtimeVersion: string expected";
       if (
@@ -496,8 +615,12 @@ export const transit_realtime = ($root.transit_realtime = (() => {
      * @param {Object.<string,*>} object Plain object
      * @returns {transit_realtime.FeedHeader} FeedHeader
      */
-    FeedHeader.fromObject = function fromObject(object) {
+    FeedHeader.fromObject = function fromObject(object, _depth) {
       if (object instanceof $root.transit_realtime.FeedHeader) return object;
+      if (!$util.isObject(object))
+        throw TypeError(".transit_realtime.FeedHeader: object expected");
+      if (_depth === undefined) _depth = 0;
+      if (_depth > $util.recursionLimit) throw Error("max depth exceeded");
       let message = new $root.transit_realtime.FeedHeader();
       if (object.gtfsRealtimeVersion != null)
         message.gtfsRealtimeVersion = String(object.gtfsRealtimeVersion);
@@ -519,9 +642,7 @@ export const transit_realtime = ($root.transit_realtime = (() => {
       }
       if (object.timestamp != null)
         if ($util.Long)
-          (message.timestamp = $util.Long.fromValue(
-            object.timestamp
-          )).unsigned = true;
+          message.timestamp = $util.Long.fromValue(object.timestamp, true);
         else if (typeof object.timestamp === "string")
           message.timestamp = parseInt(object.timestamp, 10);
         else if (typeof object.timestamp === "number")
@@ -543,8 +664,10 @@ export const transit_realtime = ($root.transit_realtime = (() => {
      * @param {$protobuf.IConversionOptions} [options] Conversion options
      * @returns {Object.<string,*>} Plain object
      */
-    FeedHeader.toObject = function toObject(message, options) {
+    FeedHeader.toObject = function toObject(message, options, _depth) {
       if (!options) options = {};
+      if (_depth === undefined) _depth = 0;
+      if (_depth > $util.recursionLimit) throw Error("max depth exceeded");
       let object = {};
       if (options.defaults) {
         object.gtfsRealtimeVersion = "";
@@ -556,8 +679,16 @@ export const transit_realtime = ($root.transit_realtime = (() => {
               ? long.toString()
               : options.longs === Number
               ? long.toNumber()
+              : typeof BigInt !== "undefined" && options.longs === BigInt
+              ? long.toBigInt()
               : long;
-        } else object.timestamp = options.longs === String ? "0" : 0;
+        } else
+          object.timestamp =
+            options.longs === String
+              ? "0"
+              : typeof BigInt !== "undefined" && options.longs === BigInt
+              ? BigInt("0")
+              : 0;
       }
       if (
         message.gtfsRealtimeVersion != null &&
@@ -579,7 +710,16 @@ export const transit_realtime = ($root.transit_realtime = (() => {
                 ]
             : message.incrementality;
       if (message.timestamp != null && message.hasOwnProperty("timestamp"))
-        if (typeof message.timestamp === "number")
+        if (typeof BigInt !== "undefined" && options.longs === BigInt)
+          object.timestamp =
+            typeof message.timestamp === "number"
+              ? BigInt(message.timestamp)
+              : $util.Long.fromBits(
+                  message.timestamp.low >>> 0,
+                  message.timestamp.high >>> 0,
+                  true
+                ).toBigInt();
+        else if (typeof message.timestamp === "number")
           object.timestamp =
             options.longs === String
               ? String(message.timestamp)
@@ -609,18 +749,16 @@ export const transit_realtime = ($root.transit_realtime = (() => {
     };
 
     /**
-     * Gets the default type url for FeedHeader
+     * Gets the type url for FeedHeader
      * @function getTypeUrl
      * @memberof transit_realtime.FeedHeader
      * @static
-     * @param {string} [typeUrlPrefix] your custom typeUrlPrefix(default "type.googleapis.com")
-     * @returns {string} The default type url
+     * @param {string} [prefix] Custom type url prefix, defaults to `"type.googleapis.com"`
+     * @returns {string} The type url
      */
-    FeedHeader.getTypeUrl = function getTypeUrl(typeUrlPrefix) {
-      if (typeUrlPrefix === undefined) {
-        typeUrlPrefix = "type.googleapis.com";
-      }
-      return typeUrlPrefix + "/transit_realtime.FeedHeader";
+    FeedHeader.getTypeUrl = function getTypeUrl(prefix) {
+      if (prefix === undefined) prefix = "type.googleapis.com";
+      return prefix + "/transit_realtime.FeedHeader";
     };
 
     /**
@@ -644,27 +782,41 @@ export const transit_realtime = ($root.transit_realtime = (() => {
   transit_realtime.FeedEntity = (function () {
     /**
      * Properties of a FeedEntity.
-     * @memberof transit_realtime
-     * @interface IFeedEntity
+     * @typedef {Object} transit_realtime.FeedEntity.$Properties
      * @property {string} id FeedEntity id
      * @property {boolean|null} [isDeleted] FeedEntity isDeleted
-     * @property {transit_realtime.ITripUpdate|null} [tripUpdate] FeedEntity tripUpdate
-     * @property {transit_realtime.IVehiclePosition|null} [vehicle] FeedEntity vehicle
-     * @property {transit_realtime.IAlert|null} [alert] FeedEntity alert
+     * @property {transit_realtime.TripUpdate.$Properties|null} [tripUpdate] FeedEntity tripUpdate
+     * @property {transit_realtime.VehiclePosition.$Properties|null} [vehicle] FeedEntity vehicle
+     * @property {transit_realtime.Alert.$Properties|null} [alert] FeedEntity alert
+     * @property {Array.<Uint8Array>} [$unknowns] Unknown fields preserved while decoding
+     */
+
+    /**
+     * Properties of a FeedEntity.
+     * @memberof transit_realtime
+     * @interface IFeedEntity
+     * @augments transit_realtime.FeedEntity.$Properties
+     * @deprecated Use transit_realtime.FeedEntity.$Properties instead.
+     */
+
+    /**
+     * Shape of a FeedEntity.
+     * @typedef {transit_realtime.FeedEntity.$Properties} transit_realtime.FeedEntity.$Shape
      */
 
     /**
      * Constructs a new FeedEntity.
      * @memberof transit_realtime
      * @classdesc Represents a FeedEntity.
-     * @implements IFeedEntity
      * @constructor
-     * @param {transit_realtime.IFeedEntity=} [properties] Properties to set
+     * @param {transit_realtime.FeedEntity.$Properties=} [properties] Properties to set
+     * @property {Array.<Uint8Array>} [$unknowns] Unknown fields preserved while decoding
      */
     function FeedEntity(properties) {
       if (properties)
         for (let keys = Object.keys(properties), i = 0; i < keys.length; ++i)
-          if (properties[keys[i]] != null) this[keys[i]] = properties[keys[i]];
+          if (properties[keys[i]] != null && keys[i] !== "__proto__")
+            this[keys[i]] = properties[keys[i]];
     }
 
     /**
@@ -685,7 +837,7 @@ export const transit_realtime = ($root.transit_realtime = (() => {
 
     /**
      * FeedEntity tripUpdate.
-     * @member {transit_realtime.ITripUpdate|null|undefined} tripUpdate
+     * @member {transit_realtime.TripUpdate.$Properties|null|undefined} tripUpdate
      * @memberof transit_realtime.FeedEntity
      * @instance
      */
@@ -693,7 +845,7 @@ export const transit_realtime = ($root.transit_realtime = (() => {
 
     /**
      * FeedEntity vehicle.
-     * @member {transit_realtime.IVehiclePosition|null|undefined} vehicle
+     * @member {transit_realtime.VehiclePosition.$Properties|null|undefined} vehicle
      * @memberof transit_realtime.FeedEntity
      * @instance
      */
@@ -701,7 +853,7 @@ export const transit_realtime = ($root.transit_realtime = (() => {
 
     /**
      * FeedEntity alert.
-     * @member {transit_realtime.IAlert|null|undefined} alert
+     * @member {transit_realtime.Alert.$Properties|null|undefined} alert
      * @memberof transit_realtime.FeedEntity
      * @instance
      */
@@ -712,8 +864,12 @@ export const transit_realtime = ($root.transit_realtime = (() => {
      * @function create
      * @memberof transit_realtime.FeedEntity
      * @static
-     * @param {transit_realtime.IFeedEntity=} [properties] Properties to set
+     * @param {transit_realtime.FeedEntity.$Properties=} [properties] Properties to set
      * @returns {transit_realtime.FeedEntity} FeedEntity instance
+     * @type {{
+     *   (properties: transit_realtime.FeedEntity.$Shape): transit_realtime.FeedEntity & transit_realtime.FeedEntity.$Shape;
+     *   (properties?: transit_realtime.FeedEntity.$Properties): transit_realtime.FeedEntity;
+     * }}
      */
     FeedEntity.create = function create(properties) {
       return new FeedEntity(properties);
@@ -724,12 +880,14 @@ export const transit_realtime = ($root.transit_realtime = (() => {
      * @function encode
      * @memberof transit_realtime.FeedEntity
      * @static
-     * @param {transit_realtime.IFeedEntity} message FeedEntity message or plain object to encode
+     * @param {transit_realtime.FeedEntity.$Properties} message FeedEntity message or plain object to encode
      * @param {$protobuf.Writer} [writer] Writer to encode to
      * @returns {$protobuf.Writer} Writer
      */
-    FeedEntity.encode = function encode(message, writer) {
+    FeedEntity.encode = function encode(message, writer, _depth) {
       if (!writer) writer = $Writer.create();
+      if (_depth === undefined) _depth = 0;
+      if (_depth > $util.recursionLimit) throw Error("max depth exceeded");
       writer.uint32(/* id 1, wireType 2 =*/ 10).string(message.id);
       if (
         message.isDeleted != null &&
@@ -742,7 +900,8 @@ export const transit_realtime = ($root.transit_realtime = (() => {
       )
         $root.transit_realtime.TripUpdate.encode(
           message.tripUpdate,
-          writer.uint32(/* id 3, wireType 2 =*/ 26).fork()
+          writer.uint32(/* id 3, wireType 2 =*/ 26).fork(),
+          _depth + 1
         ).ldelim();
       if (
         message.vehicle != null &&
@@ -750,13 +909,21 @@ export const transit_realtime = ($root.transit_realtime = (() => {
       )
         $root.transit_realtime.VehiclePosition.encode(
           message.vehicle,
-          writer.uint32(/* id 4, wireType 2 =*/ 34).fork()
+          writer.uint32(/* id 4, wireType 2 =*/ 34).fork(),
+          _depth + 1
         ).ldelim();
       if (message.alert != null && Object.hasOwnProperty.call(message, "alert"))
         $root.transit_realtime.Alert.encode(
           message.alert,
-          writer.uint32(/* id 5, wireType 2 =*/ 42).fork()
+          writer.uint32(/* id 5, wireType 2 =*/ 42).fork(),
+          _depth + 1
         ).ldelim();
+      if (
+        message.$unknowns != null &&
+        Object.hasOwnProperty.call(message, "$unknowns")
+      )
+        for (let i = 0; i < message.$unknowns.length; ++i)
+          writer.raw(message.$unknowns[i]);
       return writer;
     };
 
@@ -765,12 +932,15 @@ export const transit_realtime = ($root.transit_realtime = (() => {
      * @function encodeDelimited
      * @memberof transit_realtime.FeedEntity
      * @static
-     * @param {transit_realtime.IFeedEntity} message FeedEntity message or plain object to encode
+     * @param {transit_realtime.FeedEntity.$Properties} message FeedEntity message or plain object to encode
      * @param {$protobuf.Writer} [writer] Writer to encode to
      * @returns {$protobuf.Writer} Writer
      */
     FeedEntity.encodeDelimited = function encodeDelimited(message, writer) {
-      return this.encode(message, writer).ldelim();
+      return this.encode(
+        message,
+        writer && writer.len ? writer.fork() : writer
+      ).ldelim();
     };
 
     /**
@@ -780,52 +950,78 @@ export const transit_realtime = ($root.transit_realtime = (() => {
      * @static
      * @param {$protobuf.Reader|Uint8Array} reader Reader or buffer to decode from
      * @param {number} [length] Message length if known beforehand
-     * @returns {transit_realtime.FeedEntity} FeedEntity
+     * @returns {transit_realtime.FeedEntity & transit_realtime.FeedEntity.$Shape} FeedEntity
      * @throws {Error} If the payload is not a reader or valid buffer
      * @throws {$protobuf.util.ProtocolError} If required fields are missing
      */
-    FeedEntity.decode = function decode(reader, length, error) {
+    FeedEntity.decode = function decode(reader, length, _end, _depth, _target) {
       if (!(reader instanceof $Reader)) reader = $Reader.create(reader);
+      if (_depth === undefined) _depth = 0;
+      if (_depth > $Reader.recursionLimit) throw Error("max depth exceeded");
       let end = length === undefined ? reader.len : reader.pos + length,
-        message = new $root.transit_realtime.FeedEntity();
+        message = _target || new $root.transit_realtime.FeedEntity();
       while (reader.pos < end) {
-        let tag = reader.uint32();
-        if (tag === error) break;
-        switch (tag >>> 3) {
+        let start = reader.pos;
+        let tag = reader.tag();
+        if (tag === _end) {
+          _end = undefined;
+          break;
+        }
+        let wireType = tag & 7;
+        switch ((tag >>>= 3)) {
           case 1: {
+            if (wireType !== 2) break;
             message.id = reader.string();
-            break;
+            continue;
           }
           case 2: {
+            if (wireType !== 0) break;
             message.isDeleted = reader.bool();
-            break;
+            continue;
           }
           case 3: {
+            if (wireType !== 2) break;
             message.tripUpdate = $root.transit_realtime.TripUpdate.decode(
               reader,
-              reader.uint32()
+              reader.uint32(),
+              undefined,
+              _depth + 1,
+              message.tripUpdate
             );
-            break;
+            continue;
           }
           case 4: {
+            if (wireType !== 2) break;
             message.vehicle = $root.transit_realtime.VehiclePosition.decode(
               reader,
-              reader.uint32()
+              reader.uint32(),
+              undefined,
+              _depth + 1,
+              message.vehicle
             );
-            break;
+            continue;
           }
           case 5: {
+            if (wireType !== 2) break;
             message.alert = $root.transit_realtime.Alert.decode(
               reader,
-              reader.uint32()
+              reader.uint32(),
+              undefined,
+              _depth + 1,
+              message.alert
             );
-            break;
+            continue;
           }
-          default:
-            reader.skipType(tag & 7);
-            break;
+        }
+        reader.skipType(wireType, _depth, tag);
+        if (!reader.discardUnknown) {
+          $util.makeProp(message, "$unknowns", false);
+          (message.$unknowns || (message.$unknowns = [])).push(
+            reader.raw(start, reader.pos)
+          );
         }
       }
+      if (_end !== undefined) throw Error("missing end group");
       if (!message.hasOwnProperty("id"))
         throw $util.ProtocolError("missing required 'id'", {
           instance: message,
@@ -839,7 +1035,7 @@ export const transit_realtime = ($root.transit_realtime = (() => {
      * @memberof transit_realtime.FeedEntity
      * @static
      * @param {$protobuf.Reader|Uint8Array} reader Reader or buffer to decode from
-     * @returns {transit_realtime.FeedEntity} FeedEntity
+     * @returns {transit_realtime.FeedEntity & transit_realtime.FeedEntity.$Shape} FeedEntity
      * @throws {Error} If the payload is not a reader or valid buffer
      * @throws {$protobuf.util.ProtocolError} If required fields are missing
      */
@@ -856,27 +1052,34 @@ export const transit_realtime = ($root.transit_realtime = (() => {
      * @param {Object.<string,*>} message Plain object to verify
      * @returns {string|null} `null` if valid, otherwise the reason why it is not
      */
-    FeedEntity.verify = function verify(message) {
+    FeedEntity.verify = function verify(message, _depth) {
       if (typeof message !== "object" || message === null)
         return "object expected";
+      if (_depth === undefined) _depth = 0;
+      if (_depth > $util.recursionLimit) return "max depth exceeded";
       if (!$util.isString(message.id)) return "id: string expected";
       if (message.isDeleted != null && message.hasOwnProperty("isDeleted"))
         if (typeof message.isDeleted !== "boolean")
           return "isDeleted: boolean expected";
       if (message.tripUpdate != null && message.hasOwnProperty("tripUpdate")) {
         let error = $root.transit_realtime.TripUpdate.verify(
-          message.tripUpdate
+          message.tripUpdate,
+          _depth + 1
         );
         if (error) return "tripUpdate." + error;
       }
       if (message.vehicle != null && message.hasOwnProperty("vehicle")) {
         let error = $root.transit_realtime.VehiclePosition.verify(
-          message.vehicle
+          message.vehicle,
+          _depth + 1
         );
         if (error) return "vehicle." + error;
       }
       if (message.alert != null && message.hasOwnProperty("alert")) {
-        let error = $root.transit_realtime.Alert.verify(message.alert);
+        let error = $root.transit_realtime.Alert.verify(
+          message.alert,
+          _depth + 1
+        );
         if (error) return "alert." + error;
       }
       return null;
@@ -890,36 +1093,45 @@ export const transit_realtime = ($root.transit_realtime = (() => {
      * @param {Object.<string,*>} object Plain object
      * @returns {transit_realtime.FeedEntity} FeedEntity
      */
-    FeedEntity.fromObject = function fromObject(object) {
+    FeedEntity.fromObject = function fromObject(object, _depth) {
       if (object instanceof $root.transit_realtime.FeedEntity) return object;
+      if (!$util.isObject(object))
+        throw TypeError(".transit_realtime.FeedEntity: object expected");
+      if (_depth === undefined) _depth = 0;
+      if (_depth > $util.recursionLimit) throw Error("max depth exceeded");
       let message = new $root.transit_realtime.FeedEntity();
       if (object.id != null) message.id = String(object.id);
       if (object.isDeleted != null)
         message.isDeleted = Boolean(object.isDeleted);
       if (object.tripUpdate != null) {
-        if (typeof object.tripUpdate !== "object")
+        if (!$util.isObject(object.tripUpdate))
           throw TypeError(
             ".transit_realtime.FeedEntity.tripUpdate: object expected"
           );
         message.tripUpdate = $root.transit_realtime.TripUpdate.fromObject(
-          object.tripUpdate
+          object.tripUpdate,
+          _depth + 1
         );
       }
       if (object.vehicle != null) {
-        if (typeof object.vehicle !== "object")
+        if (!$util.isObject(object.vehicle))
           throw TypeError(
             ".transit_realtime.FeedEntity.vehicle: object expected"
           );
         message.vehicle = $root.transit_realtime.VehiclePosition.fromObject(
-          object.vehicle
+          object.vehicle,
+          _depth + 1
         );
       }
       if (object.alert != null) {
-        if (typeof object.alert !== "object")
+        if (!$util.isObject(object.alert))
           throw TypeError(
             ".transit_realtime.FeedEntity.alert: object expected"
           );
-        message.alert = $root.transit_realtime.Alert.fromObject(object.alert);
+        message.alert = $root.transit_realtime.Alert.fromObject(
+          object.alert,
+          _depth + 1
+        );
       }
       return message;
     };
@@ -933,8 +1145,10 @@ export const transit_realtime = ($root.transit_realtime = (() => {
      * @param {$protobuf.IConversionOptions} [options] Conversion options
      * @returns {Object.<string,*>} Plain object
      */
-    FeedEntity.toObject = function toObject(message, options) {
+    FeedEntity.toObject = function toObject(message, options, _depth) {
       if (!options) options = {};
+      if (_depth === undefined) _depth = 0;
+      if (_depth > $util.recursionLimit) throw Error("max depth exceeded");
       let object = {};
       if (options.defaults) {
         object.id = "";
@@ -950,17 +1164,20 @@ export const transit_realtime = ($root.transit_realtime = (() => {
       if (message.tripUpdate != null && message.hasOwnProperty("tripUpdate"))
         object.tripUpdate = $root.transit_realtime.TripUpdate.toObject(
           message.tripUpdate,
-          options
+          options,
+          _depth + 1
         );
       if (message.vehicle != null && message.hasOwnProperty("vehicle"))
         object.vehicle = $root.transit_realtime.VehiclePosition.toObject(
           message.vehicle,
-          options
+          options,
+          _depth + 1
         );
       if (message.alert != null && message.hasOwnProperty("alert"))
         object.alert = $root.transit_realtime.Alert.toObject(
           message.alert,
-          options
+          options,
+          _depth + 1
         );
       return object;
     };
@@ -977,18 +1194,16 @@ export const transit_realtime = ($root.transit_realtime = (() => {
     };
 
     /**
-     * Gets the default type url for FeedEntity
+     * Gets the type url for FeedEntity
      * @function getTypeUrl
      * @memberof transit_realtime.FeedEntity
      * @static
-     * @param {string} [typeUrlPrefix] your custom typeUrlPrefix(default "type.googleapis.com")
-     * @returns {string} The default type url
+     * @param {string} [prefix] Custom type url prefix, defaults to `"type.googleapis.com"`
+     * @returns {string} The type url
      */
-    FeedEntity.getTypeUrl = function getTypeUrl(typeUrlPrefix) {
-      if (typeUrlPrefix === undefined) {
-        typeUrlPrefix = "type.googleapis.com";
-      }
-      return typeUrlPrefix + "/transit_realtime.FeedEntity";
+    FeedEntity.getTypeUrl = function getTypeUrl(prefix) {
+      if (prefix === undefined) prefix = "type.googleapis.com";
+      return prefix + "/transit_realtime.FeedEntity";
     };
 
     return FeedEntity;
@@ -997,33 +1212,47 @@ export const transit_realtime = ($root.transit_realtime = (() => {
   transit_realtime.TripUpdate = (function () {
     /**
      * Properties of a TripUpdate.
-     * @memberof transit_realtime
-     * @interface ITripUpdate
-     * @property {transit_realtime.ITripDescriptor} trip TripUpdate trip
-     * @property {transit_realtime.IVehicleDescriptor|null} [vehicle] TripUpdate vehicle
-     * @property {Array.<transit_realtime.TripUpdate.IStopTimeUpdate>|null} [stopTimeUpdate] TripUpdate stopTimeUpdate
+     * @typedef {Object} transit_realtime.TripUpdate.$Properties
+     * @property {transit_realtime.TripDescriptor.$Properties} trip TripUpdate trip
+     * @property {transit_realtime.VehicleDescriptor.$Properties|null} [vehicle] TripUpdate vehicle
+     * @property {Array.<transit_realtime.TripUpdate.StopTimeUpdate.$Properties>|null} [stopTimeUpdate] TripUpdate stopTimeUpdate
      * @property {number|Long|null} [timestamp] TripUpdate timestamp
      * @property {number|null} [delay] TripUpdate delay
+     * @property {Array.<Uint8Array>} [$unknowns] Unknown fields preserved while decoding
+     */
+
+    /**
+     * Properties of a TripUpdate.
+     * @memberof transit_realtime
+     * @interface ITripUpdate
+     * @augments transit_realtime.TripUpdate.$Properties
+     * @deprecated Use transit_realtime.TripUpdate.$Properties instead.
+     */
+
+    /**
+     * Shape of a TripUpdate.
+     * @typedef {transit_realtime.TripUpdate.$Properties} transit_realtime.TripUpdate.$Shape
      */
 
     /**
      * Constructs a new TripUpdate.
      * @memberof transit_realtime
      * @classdesc Represents a TripUpdate.
-     * @implements ITripUpdate
      * @constructor
-     * @param {transit_realtime.ITripUpdate=} [properties] Properties to set
+     * @param {transit_realtime.TripUpdate.$Properties=} [properties] Properties to set
+     * @property {Array.<Uint8Array>} [$unknowns] Unknown fields preserved while decoding
      */
     function TripUpdate(properties) {
       this.stopTimeUpdate = [];
       if (properties)
         for (let keys = Object.keys(properties), i = 0; i < keys.length; ++i)
-          if (properties[keys[i]] != null) this[keys[i]] = properties[keys[i]];
+          if (properties[keys[i]] != null && keys[i] !== "__proto__")
+            this[keys[i]] = properties[keys[i]];
     }
 
     /**
      * TripUpdate trip.
-     * @member {transit_realtime.ITripDescriptor} trip
+     * @member {transit_realtime.TripDescriptor.$Properties} trip
      * @memberof transit_realtime.TripUpdate
      * @instance
      */
@@ -1031,7 +1260,7 @@ export const transit_realtime = ($root.transit_realtime = (() => {
 
     /**
      * TripUpdate vehicle.
-     * @member {transit_realtime.IVehicleDescriptor|null|undefined} vehicle
+     * @member {transit_realtime.VehicleDescriptor.$Properties|null|undefined} vehicle
      * @memberof transit_realtime.TripUpdate
      * @instance
      */
@@ -1039,7 +1268,7 @@ export const transit_realtime = ($root.transit_realtime = (() => {
 
     /**
      * TripUpdate stopTimeUpdate.
-     * @member {Array.<transit_realtime.TripUpdate.IStopTimeUpdate>} stopTimeUpdate
+     * @member {Array.<transit_realtime.TripUpdate.StopTimeUpdate.$Properties>} stopTimeUpdate
      * @memberof transit_realtime.TripUpdate
      * @instance
      */
@@ -1068,8 +1297,12 @@ export const transit_realtime = ($root.transit_realtime = (() => {
      * @function create
      * @memberof transit_realtime.TripUpdate
      * @static
-     * @param {transit_realtime.ITripUpdate=} [properties] Properties to set
+     * @param {transit_realtime.TripUpdate.$Properties=} [properties] Properties to set
      * @returns {transit_realtime.TripUpdate} TripUpdate instance
+     * @type {{
+     *   (properties: transit_realtime.TripUpdate.$Shape): transit_realtime.TripUpdate & transit_realtime.TripUpdate.$Shape;
+     *   (properties?: transit_realtime.TripUpdate.$Properties): transit_realtime.TripUpdate;
+     * }}
      */
     TripUpdate.create = function create(properties) {
       return new TripUpdate(properties);
@@ -1080,21 +1313,25 @@ export const transit_realtime = ($root.transit_realtime = (() => {
      * @function encode
      * @memberof transit_realtime.TripUpdate
      * @static
-     * @param {transit_realtime.ITripUpdate} message TripUpdate message or plain object to encode
+     * @param {transit_realtime.TripUpdate.$Properties} message TripUpdate message or plain object to encode
      * @param {$protobuf.Writer} [writer] Writer to encode to
      * @returns {$protobuf.Writer} Writer
      */
-    TripUpdate.encode = function encode(message, writer) {
+    TripUpdate.encode = function encode(message, writer, _depth) {
       if (!writer) writer = $Writer.create();
+      if (_depth === undefined) _depth = 0;
+      if (_depth > $util.recursionLimit) throw Error("max depth exceeded");
       $root.transit_realtime.TripDescriptor.encode(
         message.trip,
-        writer.uint32(/* id 1, wireType 2 =*/ 10).fork()
+        writer.uint32(/* id 1, wireType 2 =*/ 10).fork(),
+        _depth + 1
       ).ldelim();
       if (message.stopTimeUpdate != null && message.stopTimeUpdate.length)
         for (let i = 0; i < message.stopTimeUpdate.length; ++i)
           $root.transit_realtime.TripUpdate.StopTimeUpdate.encode(
             message.stopTimeUpdate[i],
-            writer.uint32(/* id 2, wireType 2 =*/ 18).fork()
+            writer.uint32(/* id 2, wireType 2 =*/ 18).fork(),
+            _depth + 1
           ).ldelim();
       if (
         message.vehicle != null &&
@@ -1102,7 +1339,8 @@ export const transit_realtime = ($root.transit_realtime = (() => {
       )
         $root.transit_realtime.VehicleDescriptor.encode(
           message.vehicle,
-          writer.uint32(/* id 3, wireType 2 =*/ 26).fork()
+          writer.uint32(/* id 3, wireType 2 =*/ 26).fork(),
+          _depth + 1
         ).ldelim();
       if (
         message.timestamp != null &&
@@ -1111,6 +1349,12 @@ export const transit_realtime = ($root.transit_realtime = (() => {
         writer.uint32(/* id 4, wireType 0 =*/ 32).uint64(message.timestamp);
       if (message.delay != null && Object.hasOwnProperty.call(message, "delay"))
         writer.uint32(/* id 5, wireType 0 =*/ 40).int32(message.delay);
+      if (
+        message.$unknowns != null &&
+        Object.hasOwnProperty.call(message, "$unknowns")
+      )
+        for (let i = 0; i < message.$unknowns.length; ++i)
+          writer.raw(message.$unknowns[i]);
       return writer;
     };
 
@@ -1119,12 +1363,15 @@ export const transit_realtime = ($root.transit_realtime = (() => {
      * @function encodeDelimited
      * @memberof transit_realtime.TripUpdate
      * @static
-     * @param {transit_realtime.ITripUpdate} message TripUpdate message or plain object to encode
+     * @param {transit_realtime.TripUpdate.$Properties} message TripUpdate message or plain object to encode
      * @param {$protobuf.Writer} [writer] Writer to encode to
      * @returns {$protobuf.Writer} Writer
      */
     TripUpdate.encodeDelimited = function encodeDelimited(message, writer) {
-      return this.encode(message, writer).ldelim();
+      return this.encode(
+        message,
+        writer && writer.len ? writer.fork() : writer
+      ).ldelim();
     };
 
     /**
@@ -1134,56 +1381,81 @@ export const transit_realtime = ($root.transit_realtime = (() => {
      * @static
      * @param {$protobuf.Reader|Uint8Array} reader Reader or buffer to decode from
      * @param {number} [length] Message length if known beforehand
-     * @returns {transit_realtime.TripUpdate} TripUpdate
+     * @returns {transit_realtime.TripUpdate & transit_realtime.TripUpdate.$Shape} TripUpdate
      * @throws {Error} If the payload is not a reader or valid buffer
      * @throws {$protobuf.util.ProtocolError} If required fields are missing
      */
-    TripUpdate.decode = function decode(reader, length, error) {
+    TripUpdate.decode = function decode(reader, length, _end, _depth, _target) {
       if (!(reader instanceof $Reader)) reader = $Reader.create(reader);
+      if (_depth === undefined) _depth = 0;
+      if (_depth > $Reader.recursionLimit) throw Error("max depth exceeded");
       let end = length === undefined ? reader.len : reader.pos + length,
-        message = new $root.transit_realtime.TripUpdate();
+        message = _target || new $root.transit_realtime.TripUpdate();
       while (reader.pos < end) {
-        let tag = reader.uint32();
-        if (tag === error) break;
-        switch (tag >>> 3) {
+        let start = reader.pos;
+        let tag = reader.tag();
+        if (tag === _end) {
+          _end = undefined;
+          break;
+        }
+        let wireType = tag & 7;
+        switch ((tag >>>= 3)) {
           case 1: {
+            if (wireType !== 2) break;
             message.trip = $root.transit_realtime.TripDescriptor.decode(
               reader,
-              reader.uint32()
+              reader.uint32(),
+              undefined,
+              _depth + 1,
+              message.trip
             );
-            break;
+            continue;
           }
           case 3: {
+            if (wireType !== 2) break;
             message.vehicle = $root.transit_realtime.VehicleDescriptor.decode(
               reader,
-              reader.uint32()
+              reader.uint32(),
+              undefined,
+              _depth + 1,
+              message.vehicle
             );
-            break;
+            continue;
           }
           case 2: {
+            if (wireType !== 2) break;
             if (!(message.stopTimeUpdate && message.stopTimeUpdate.length))
               message.stopTimeUpdate = [];
             message.stopTimeUpdate.push(
               $root.transit_realtime.TripUpdate.StopTimeUpdate.decode(
                 reader,
-                reader.uint32()
+                reader.uint32(),
+                undefined,
+                _depth + 1
               )
             );
-            break;
+            continue;
           }
           case 4: {
+            if (wireType !== 0) break;
             message.timestamp = reader.uint64();
-            break;
+            continue;
           }
           case 5: {
+            if (wireType !== 0) break;
             message.delay = reader.int32();
-            break;
+            continue;
           }
-          default:
-            reader.skipType(tag & 7);
-            break;
+        }
+        reader.skipType(wireType, _depth, tag);
+        if (!reader.discardUnknown) {
+          $util.makeProp(message, "$unknowns", false);
+          (message.$unknowns || (message.$unknowns = [])).push(
+            reader.raw(start, reader.pos)
+          );
         }
       }
+      if (_end !== undefined) throw Error("missing end group");
       if (!message.hasOwnProperty("trip"))
         throw $util.ProtocolError("missing required 'trip'", {
           instance: message,
@@ -1197,7 +1469,7 @@ export const transit_realtime = ($root.transit_realtime = (() => {
      * @memberof transit_realtime.TripUpdate
      * @static
      * @param {$protobuf.Reader|Uint8Array} reader Reader or buffer to decode from
-     * @returns {transit_realtime.TripUpdate} TripUpdate
+     * @returns {transit_realtime.TripUpdate & transit_realtime.TripUpdate.$Shape} TripUpdate
      * @throws {Error} If the payload is not a reader or valid buffer
      * @throws {$protobuf.util.ProtocolError} If required fields are missing
      */
@@ -1214,16 +1486,22 @@ export const transit_realtime = ($root.transit_realtime = (() => {
      * @param {Object.<string,*>} message Plain object to verify
      * @returns {string|null} `null` if valid, otherwise the reason why it is not
      */
-    TripUpdate.verify = function verify(message) {
+    TripUpdate.verify = function verify(message, _depth) {
       if (typeof message !== "object" || message === null)
         return "object expected";
+      if (_depth === undefined) _depth = 0;
+      if (_depth > $util.recursionLimit) return "max depth exceeded";
       {
-        let error = $root.transit_realtime.TripDescriptor.verify(message.trip);
+        let error = $root.transit_realtime.TripDescriptor.verify(
+          message.trip,
+          _depth + 1
+        );
         if (error) return "trip." + error;
       }
       if (message.vehicle != null && message.hasOwnProperty("vehicle")) {
         let error = $root.transit_realtime.VehicleDescriptor.verify(
-          message.vehicle
+          message.vehicle,
+          _depth + 1
         );
         if (error) return "vehicle." + error;
       }
@@ -1235,7 +1513,8 @@ export const transit_realtime = ($root.transit_realtime = (() => {
           return "stopTimeUpdate: array expected";
         for (let i = 0; i < message.stopTimeUpdate.length; ++i) {
           let error = $root.transit_realtime.TripUpdate.StopTimeUpdate.verify(
-            message.stopTimeUpdate[i]
+            message.stopTimeUpdate[i],
+            _depth + 1
           );
           if (error) return "stopTimeUpdate." + error;
         }
@@ -1263,23 +1542,29 @@ export const transit_realtime = ($root.transit_realtime = (() => {
      * @param {Object.<string,*>} object Plain object
      * @returns {transit_realtime.TripUpdate} TripUpdate
      */
-    TripUpdate.fromObject = function fromObject(object) {
+    TripUpdate.fromObject = function fromObject(object, _depth) {
       if (object instanceof $root.transit_realtime.TripUpdate) return object;
+      if (!$util.isObject(object))
+        throw TypeError(".transit_realtime.TripUpdate: object expected");
+      if (_depth === undefined) _depth = 0;
+      if (_depth > $util.recursionLimit) throw Error("max depth exceeded");
       let message = new $root.transit_realtime.TripUpdate();
       if (object.trip != null) {
-        if (typeof object.trip !== "object")
+        if (!$util.isObject(object.trip))
           throw TypeError(".transit_realtime.TripUpdate.trip: object expected");
         message.trip = $root.transit_realtime.TripDescriptor.fromObject(
-          object.trip
+          object.trip,
+          _depth + 1
         );
       }
       if (object.vehicle != null) {
-        if (typeof object.vehicle !== "object")
+        if (!$util.isObject(object.vehicle))
           throw TypeError(
             ".transit_realtime.TripUpdate.vehicle: object expected"
           );
         message.vehicle = $root.transit_realtime.VehicleDescriptor.fromObject(
-          object.vehicle
+          object.vehicle,
+          _depth + 1
         );
       }
       if (object.stopTimeUpdate) {
@@ -1287,23 +1572,22 @@ export const transit_realtime = ($root.transit_realtime = (() => {
           throw TypeError(
             ".transit_realtime.TripUpdate.stopTimeUpdate: array expected"
           );
-        message.stopTimeUpdate = [];
+        message.stopTimeUpdate = Array(object.stopTimeUpdate.length);
         for (let i = 0; i < object.stopTimeUpdate.length; ++i) {
-          if (typeof object.stopTimeUpdate[i] !== "object")
+          if (!$util.isObject(object.stopTimeUpdate[i]))
             throw TypeError(
               ".transit_realtime.TripUpdate.stopTimeUpdate: object expected"
             );
           message.stopTimeUpdate[i] =
             $root.transit_realtime.TripUpdate.StopTimeUpdate.fromObject(
-              object.stopTimeUpdate[i]
+              object.stopTimeUpdate[i],
+              _depth + 1
             );
         }
       }
       if (object.timestamp != null)
         if ($util.Long)
-          (message.timestamp = $util.Long.fromValue(
-            object.timestamp
-          )).unsigned = true;
+          message.timestamp = $util.Long.fromValue(object.timestamp, true);
         else if (typeof object.timestamp === "string")
           message.timestamp = parseInt(object.timestamp, 10);
         else if (typeof object.timestamp === "number")
@@ -1326,8 +1610,10 @@ export const transit_realtime = ($root.transit_realtime = (() => {
      * @param {$protobuf.IConversionOptions} [options] Conversion options
      * @returns {Object.<string,*>} Plain object
      */
-    TripUpdate.toObject = function toObject(message, options) {
+    TripUpdate.toObject = function toObject(message, options, _depth) {
       if (!options) options = {};
+      if (_depth === undefined) _depth = 0;
+      if (_depth > $util.recursionLimit) throw Error("max depth exceeded");
       let object = {};
       if (options.arrays || options.defaults) object.stopTimeUpdate = [];
       if (options.defaults) {
@@ -1340,31 +1626,51 @@ export const transit_realtime = ($root.transit_realtime = (() => {
               ? long.toString()
               : options.longs === Number
               ? long.toNumber()
+              : typeof BigInt !== "undefined" && options.longs === BigInt
+              ? long.toBigInt()
               : long;
-        } else object.timestamp = options.longs === String ? "0" : 0;
+        } else
+          object.timestamp =
+            options.longs === String
+              ? "0"
+              : typeof BigInt !== "undefined" && options.longs === BigInt
+              ? BigInt("0")
+              : 0;
         object.delay = 0;
       }
       if (message.trip != null && message.hasOwnProperty("trip"))
         object.trip = $root.transit_realtime.TripDescriptor.toObject(
           message.trip,
-          options
+          options,
+          _depth + 1
         );
       if (message.stopTimeUpdate && message.stopTimeUpdate.length) {
-        object.stopTimeUpdate = [];
+        object.stopTimeUpdate = Array(message.stopTimeUpdate.length);
         for (let j = 0; j < message.stopTimeUpdate.length; ++j)
           object.stopTimeUpdate[j] =
             $root.transit_realtime.TripUpdate.StopTimeUpdate.toObject(
               message.stopTimeUpdate[j],
-              options
+              options,
+              _depth + 1
             );
       }
       if (message.vehicle != null && message.hasOwnProperty("vehicle"))
         object.vehicle = $root.transit_realtime.VehicleDescriptor.toObject(
           message.vehicle,
-          options
+          options,
+          _depth + 1
         );
       if (message.timestamp != null && message.hasOwnProperty("timestamp"))
-        if (typeof message.timestamp === "number")
+        if (typeof BigInt !== "undefined" && options.longs === BigInt)
+          object.timestamp =
+            typeof message.timestamp === "number"
+              ? BigInt(message.timestamp)
+              : $util.Long.fromBits(
+                  message.timestamp.low >>> 0,
+                  message.timestamp.high >>> 0,
+                  true
+                ).toBigInt();
+        else if (typeof message.timestamp === "number")
           object.timestamp =
             options.longs === String
               ? String(message.timestamp)
@@ -1396,42 +1702,53 @@ export const transit_realtime = ($root.transit_realtime = (() => {
     };
 
     /**
-     * Gets the default type url for TripUpdate
+     * Gets the type url for TripUpdate
      * @function getTypeUrl
      * @memberof transit_realtime.TripUpdate
      * @static
-     * @param {string} [typeUrlPrefix] your custom typeUrlPrefix(default "type.googleapis.com")
-     * @returns {string} The default type url
+     * @param {string} [prefix] Custom type url prefix, defaults to `"type.googleapis.com"`
+     * @returns {string} The type url
      */
-    TripUpdate.getTypeUrl = function getTypeUrl(typeUrlPrefix) {
-      if (typeUrlPrefix === undefined) {
-        typeUrlPrefix = "type.googleapis.com";
-      }
-      return typeUrlPrefix + "/transit_realtime.TripUpdate";
+    TripUpdate.getTypeUrl = function getTypeUrl(prefix) {
+      if (prefix === undefined) prefix = "type.googleapis.com";
+      return prefix + "/transit_realtime.TripUpdate";
     };
 
     TripUpdate.StopTimeEvent = (function () {
       /**
        * Properties of a StopTimeEvent.
-       * @memberof transit_realtime.TripUpdate
-       * @interface IStopTimeEvent
+       * @typedef {Object} transit_realtime.TripUpdate.StopTimeEvent.$Properties
        * @property {number|null} [delay] StopTimeEvent delay
        * @property {number|Long|null} [time] StopTimeEvent time
        * @property {number|null} [uncertainty] StopTimeEvent uncertainty
+       * @property {Array.<Uint8Array>} [$unknowns] Unknown fields preserved while decoding
+       */
+
+      /**
+       * Properties of a StopTimeEvent.
+       * @memberof transit_realtime.TripUpdate
+       * @interface IStopTimeEvent
+       * @augments transit_realtime.TripUpdate.StopTimeEvent.$Properties
+       * @deprecated Use transit_realtime.TripUpdate.StopTimeEvent.$Properties instead.
+       */
+
+      /**
+       * Shape of a StopTimeEvent.
+       * @typedef {transit_realtime.TripUpdate.StopTimeEvent.$Properties} transit_realtime.TripUpdate.StopTimeEvent.$Shape
        */
 
       /**
        * Constructs a new StopTimeEvent.
        * @memberof transit_realtime.TripUpdate
        * @classdesc Represents a StopTimeEvent.
-       * @implements IStopTimeEvent
        * @constructor
-       * @param {transit_realtime.TripUpdate.IStopTimeEvent=} [properties] Properties to set
+       * @param {transit_realtime.TripUpdate.StopTimeEvent.$Properties=} [properties] Properties to set
+       * @property {Array.<Uint8Array>} [$unknowns] Unknown fields preserved while decoding
        */
       function StopTimeEvent(properties) {
         if (properties)
           for (let keys = Object.keys(properties), i = 0; i < keys.length; ++i)
-            if (properties[keys[i]] != null)
+            if (properties[keys[i]] != null && keys[i] !== "__proto__")
               this[keys[i]] = properties[keys[i]];
       }
 
@@ -1466,8 +1783,12 @@ export const transit_realtime = ($root.transit_realtime = (() => {
        * @function create
        * @memberof transit_realtime.TripUpdate.StopTimeEvent
        * @static
-       * @param {transit_realtime.TripUpdate.IStopTimeEvent=} [properties] Properties to set
+       * @param {transit_realtime.TripUpdate.StopTimeEvent.$Properties=} [properties] Properties to set
        * @returns {transit_realtime.TripUpdate.StopTimeEvent} StopTimeEvent instance
+       * @type {{
+       *   (properties: transit_realtime.TripUpdate.StopTimeEvent.$Shape): transit_realtime.TripUpdate.StopTimeEvent & transit_realtime.TripUpdate.StopTimeEvent.$Shape;
+       *   (properties?: transit_realtime.TripUpdate.StopTimeEvent.$Properties): transit_realtime.TripUpdate.StopTimeEvent;
+       * }}
        */
       StopTimeEvent.create = function create(properties) {
         return new StopTimeEvent(properties);
@@ -1478,12 +1799,14 @@ export const transit_realtime = ($root.transit_realtime = (() => {
        * @function encode
        * @memberof transit_realtime.TripUpdate.StopTimeEvent
        * @static
-       * @param {transit_realtime.TripUpdate.IStopTimeEvent} message StopTimeEvent message or plain object to encode
+       * @param {transit_realtime.TripUpdate.StopTimeEvent.$Properties} message StopTimeEvent message or plain object to encode
        * @param {$protobuf.Writer} [writer] Writer to encode to
        * @returns {$protobuf.Writer} Writer
        */
-      StopTimeEvent.encode = function encode(message, writer) {
+      StopTimeEvent.encode = function encode(message, writer, _depth) {
         if (!writer) writer = $Writer.create();
+        if (_depth === undefined) _depth = 0;
+        if (_depth > $util.recursionLimit) throw Error("max depth exceeded");
         if (
           message.delay != null &&
           Object.hasOwnProperty.call(message, "delay")
@@ -1496,6 +1819,12 @@ export const transit_realtime = ($root.transit_realtime = (() => {
           Object.hasOwnProperty.call(message, "uncertainty")
         )
           writer.uint32(/* id 3, wireType 0 =*/ 24).int32(message.uncertainty);
+        if (
+          message.$unknowns != null &&
+          Object.hasOwnProperty.call(message, "$unknowns")
+        )
+          for (let i = 0; i < message.$unknowns.length; ++i)
+            writer.raw(message.$unknowns[i]);
         return writer;
       };
 
@@ -1504,7 +1833,7 @@ export const transit_realtime = ($root.transit_realtime = (() => {
        * @function encodeDelimited
        * @memberof transit_realtime.TripUpdate.StopTimeEvent
        * @static
-       * @param {transit_realtime.TripUpdate.IStopTimeEvent} message StopTimeEvent message or plain object to encode
+       * @param {transit_realtime.TripUpdate.StopTimeEvent.$Properties} message StopTimeEvent message or plain object to encode
        * @param {$protobuf.Writer} [writer] Writer to encode to
        * @returns {$protobuf.Writer} Writer
        */
@@ -1512,7 +1841,10 @@ export const transit_realtime = ($root.transit_realtime = (() => {
         message,
         writer
       ) {
-        return this.encode(message, writer).ldelim();
+        return this.encode(
+          message,
+          writer && writer.len ? writer.fork() : writer
+        ).ldelim();
       };
 
       /**
@@ -1522,35 +1854,57 @@ export const transit_realtime = ($root.transit_realtime = (() => {
        * @static
        * @param {$protobuf.Reader|Uint8Array} reader Reader or buffer to decode from
        * @param {number} [length] Message length if known beforehand
-       * @returns {transit_realtime.TripUpdate.StopTimeEvent} StopTimeEvent
+       * @returns {transit_realtime.TripUpdate.StopTimeEvent & transit_realtime.TripUpdate.StopTimeEvent.$Shape} StopTimeEvent
        * @throws {Error} If the payload is not a reader or valid buffer
        * @throws {$protobuf.util.ProtocolError} If required fields are missing
        */
-      StopTimeEvent.decode = function decode(reader, length, error) {
+      StopTimeEvent.decode = function decode(
+        reader,
+        length,
+        _end,
+        _depth,
+        _target
+      ) {
         if (!(reader instanceof $Reader)) reader = $Reader.create(reader);
+        if (_depth === undefined) _depth = 0;
+        if (_depth > $Reader.recursionLimit) throw Error("max depth exceeded");
         let end = length === undefined ? reader.len : reader.pos + length,
-          message = new $root.transit_realtime.TripUpdate.StopTimeEvent();
+          message =
+            _target || new $root.transit_realtime.TripUpdate.StopTimeEvent();
         while (reader.pos < end) {
-          let tag = reader.uint32();
-          if (tag === error) break;
-          switch (tag >>> 3) {
+          let start = reader.pos;
+          let tag = reader.tag();
+          if (tag === _end) {
+            _end = undefined;
+            break;
+          }
+          let wireType = tag & 7;
+          switch ((tag >>>= 3)) {
             case 1: {
+              if (wireType !== 0) break;
               message.delay = reader.int32();
-              break;
+              continue;
             }
             case 2: {
+              if (wireType !== 0) break;
               message.time = reader.int64();
-              break;
+              continue;
             }
             case 3: {
+              if (wireType !== 0) break;
               message.uncertainty = reader.int32();
-              break;
+              continue;
             }
-            default:
-              reader.skipType(tag & 7);
-              break;
+          }
+          reader.skipType(wireType, _depth, tag);
+          if (!reader.discardUnknown) {
+            $util.makeProp(message, "$unknowns", false);
+            (message.$unknowns || (message.$unknowns = [])).push(
+              reader.raw(start, reader.pos)
+            );
           }
         }
+        if (_end !== undefined) throw Error("missing end group");
         return message;
       };
 
@@ -1560,7 +1914,7 @@ export const transit_realtime = ($root.transit_realtime = (() => {
        * @memberof transit_realtime.TripUpdate.StopTimeEvent
        * @static
        * @param {$protobuf.Reader|Uint8Array} reader Reader or buffer to decode from
-       * @returns {transit_realtime.TripUpdate.StopTimeEvent} StopTimeEvent
+       * @returns {transit_realtime.TripUpdate.StopTimeEvent & transit_realtime.TripUpdate.StopTimeEvent.$Shape} StopTimeEvent
        * @throws {Error} If the payload is not a reader or valid buffer
        * @throws {$protobuf.util.ProtocolError} If required fields are missing
        */
@@ -1577,9 +1931,11 @@ export const transit_realtime = ($root.transit_realtime = (() => {
        * @param {Object.<string,*>} message Plain object to verify
        * @returns {string|null} `null` if valid, otherwise the reason why it is not
        */
-      StopTimeEvent.verify = function verify(message) {
+      StopTimeEvent.verify = function verify(message, _depth) {
         if (typeof message !== "object" || message === null)
           return "object expected";
+        if (_depth === undefined) _depth = 0;
+        if (_depth > $util.recursionLimit) return "max depth exceeded";
         if (message.delay != null && message.hasOwnProperty("delay"))
           if (!$util.isInteger(message.delay)) return "delay: integer expected";
         if (message.time != null && message.hasOwnProperty("time"))
@@ -1609,14 +1965,20 @@ export const transit_realtime = ($root.transit_realtime = (() => {
        * @param {Object.<string,*>} object Plain object
        * @returns {transit_realtime.TripUpdate.StopTimeEvent} StopTimeEvent
        */
-      StopTimeEvent.fromObject = function fromObject(object) {
+      StopTimeEvent.fromObject = function fromObject(object, _depth) {
         if (object instanceof $root.transit_realtime.TripUpdate.StopTimeEvent)
           return object;
+        if (!$util.isObject(object))
+          throw TypeError(
+            ".transit_realtime.TripUpdate.StopTimeEvent: object expected"
+          );
+        if (_depth === undefined) _depth = 0;
+        if (_depth > $util.recursionLimit) throw Error("max depth exceeded");
         let message = new $root.transit_realtime.TripUpdate.StopTimeEvent();
         if (object.delay != null) message.delay = object.delay | 0;
         if (object.time != null)
           if ($util.Long)
-            (message.time = $util.Long.fromValue(object.time)).unsigned = false;
+            message.time = $util.Long.fromValue(object.time, false);
           else if (typeof object.time === "string")
             message.time = parseInt(object.time, 10);
           else if (typeof object.time === "number") message.time = object.time;
@@ -1639,8 +2001,10 @@ export const transit_realtime = ($root.transit_realtime = (() => {
        * @param {$protobuf.IConversionOptions} [options] Conversion options
        * @returns {Object.<string,*>} Plain object
        */
-      StopTimeEvent.toObject = function toObject(message, options) {
+      StopTimeEvent.toObject = function toObject(message, options, _depth) {
         if (!options) options = {};
+        if (_depth === undefined) _depth = 0;
+        if (_depth > $util.recursionLimit) throw Error("max depth exceeded");
         let object = {};
         if (options.defaults) {
           object.delay = 0;
@@ -1651,14 +2015,31 @@ export const transit_realtime = ($root.transit_realtime = (() => {
                 ? long.toString()
                 : options.longs === Number
                 ? long.toNumber()
+                : typeof BigInt !== "undefined" && options.longs === BigInt
+                ? long.toBigInt()
                 : long;
-          } else object.time = options.longs === String ? "0" : 0;
+          } else
+            object.time =
+              options.longs === String
+                ? "0"
+                : typeof BigInt !== "undefined" && options.longs === BigInt
+                ? BigInt("0")
+                : 0;
           object.uncertainty = 0;
         }
         if (message.delay != null && message.hasOwnProperty("delay"))
           object.delay = message.delay;
         if (message.time != null && message.hasOwnProperty("time"))
-          if (typeof message.time === "number")
+          if (typeof BigInt !== "undefined" && options.longs === BigInt)
+            object.time =
+              typeof message.time === "number"
+                ? BigInt(message.time)
+                : $util.Long.fromBits(
+                    message.time.low >>> 0,
+                    message.time.high >>> 0,
+                    false
+                  ).toBigInt();
+          else if (typeof message.time === "number")
             object.time =
               options.longs === String ? String(message.time) : message.time;
           else
@@ -1691,18 +2072,16 @@ export const transit_realtime = ($root.transit_realtime = (() => {
       };
 
       /**
-       * Gets the default type url for StopTimeEvent
+       * Gets the type url for StopTimeEvent
        * @function getTypeUrl
        * @memberof transit_realtime.TripUpdate.StopTimeEvent
        * @static
-       * @param {string} [typeUrlPrefix] your custom typeUrlPrefix(default "type.googleapis.com")
-       * @returns {string} The default type url
+       * @param {string} [prefix] Custom type url prefix, defaults to `"type.googleapis.com"`
+       * @returns {string} The type url
        */
-      StopTimeEvent.getTypeUrl = function getTypeUrl(typeUrlPrefix) {
-        if (typeUrlPrefix === undefined) {
-          typeUrlPrefix = "type.googleapis.com";
-        }
-        return typeUrlPrefix + "/transit_realtime.TripUpdate.StopTimeEvent";
+      StopTimeEvent.getTypeUrl = function getTypeUrl(prefix) {
+        if (prefix === undefined) prefix = "type.googleapis.com";
+        return prefix + "/transit_realtime.TripUpdate.StopTimeEvent";
       };
 
       return StopTimeEvent;
@@ -1711,27 +2090,40 @@ export const transit_realtime = ($root.transit_realtime = (() => {
     TripUpdate.StopTimeUpdate = (function () {
       /**
        * Properties of a StopTimeUpdate.
-       * @memberof transit_realtime.TripUpdate
-       * @interface IStopTimeUpdate
+       * @typedef {Object} transit_realtime.TripUpdate.StopTimeUpdate.$Properties
        * @property {number|null} [stopSequence] StopTimeUpdate stopSequence
        * @property {string|null} [stopId] StopTimeUpdate stopId
-       * @property {transit_realtime.TripUpdate.IStopTimeEvent|null} [arrival] StopTimeUpdate arrival
-       * @property {transit_realtime.TripUpdate.IStopTimeEvent|null} [departure] StopTimeUpdate departure
+       * @property {transit_realtime.TripUpdate.StopTimeEvent.$Properties|null} [arrival] StopTimeUpdate arrival
+       * @property {transit_realtime.TripUpdate.StopTimeEvent.$Properties|null} [departure] StopTimeUpdate departure
        * @property {transit_realtime.TripUpdate.StopTimeUpdate.ScheduleRelationship|null} [scheduleRelationship] StopTimeUpdate scheduleRelationship
+       * @property {Array.<Uint8Array>} [$unknowns] Unknown fields preserved while decoding
+       */
+
+      /**
+       * Properties of a StopTimeUpdate.
+       * @memberof transit_realtime.TripUpdate
+       * @interface IStopTimeUpdate
+       * @augments transit_realtime.TripUpdate.StopTimeUpdate.$Properties
+       * @deprecated Use transit_realtime.TripUpdate.StopTimeUpdate.$Properties instead.
+       */
+
+      /**
+       * Shape of a StopTimeUpdate.
+       * @typedef {transit_realtime.TripUpdate.StopTimeUpdate.$Properties} transit_realtime.TripUpdate.StopTimeUpdate.$Shape
        */
 
       /**
        * Constructs a new StopTimeUpdate.
        * @memberof transit_realtime.TripUpdate
        * @classdesc Represents a StopTimeUpdate.
-       * @implements IStopTimeUpdate
        * @constructor
-       * @param {transit_realtime.TripUpdate.IStopTimeUpdate=} [properties] Properties to set
+       * @param {transit_realtime.TripUpdate.StopTimeUpdate.$Properties=} [properties] Properties to set
+       * @property {Array.<Uint8Array>} [$unknowns] Unknown fields preserved while decoding
        */
       function StopTimeUpdate(properties) {
         if (properties)
           for (let keys = Object.keys(properties), i = 0; i < keys.length; ++i)
-            if (properties[keys[i]] != null)
+            if (properties[keys[i]] != null && keys[i] !== "__proto__")
               this[keys[i]] = properties[keys[i]];
       }
 
@@ -1753,7 +2145,7 @@ export const transit_realtime = ($root.transit_realtime = (() => {
 
       /**
        * StopTimeUpdate arrival.
-       * @member {transit_realtime.TripUpdate.IStopTimeEvent|null|undefined} arrival
+       * @member {transit_realtime.TripUpdate.StopTimeEvent.$Properties|null|undefined} arrival
        * @memberof transit_realtime.TripUpdate.StopTimeUpdate
        * @instance
        */
@@ -1761,7 +2153,7 @@ export const transit_realtime = ($root.transit_realtime = (() => {
 
       /**
        * StopTimeUpdate departure.
-       * @member {transit_realtime.TripUpdate.IStopTimeEvent|null|undefined} departure
+       * @member {transit_realtime.TripUpdate.StopTimeEvent.$Properties|null|undefined} departure
        * @memberof transit_realtime.TripUpdate.StopTimeUpdate
        * @instance
        */
@@ -1780,8 +2172,12 @@ export const transit_realtime = ($root.transit_realtime = (() => {
        * @function create
        * @memberof transit_realtime.TripUpdate.StopTimeUpdate
        * @static
-       * @param {transit_realtime.TripUpdate.IStopTimeUpdate=} [properties] Properties to set
+       * @param {transit_realtime.TripUpdate.StopTimeUpdate.$Properties=} [properties] Properties to set
        * @returns {transit_realtime.TripUpdate.StopTimeUpdate} StopTimeUpdate instance
+       * @type {{
+       *   (properties: transit_realtime.TripUpdate.StopTimeUpdate.$Shape): transit_realtime.TripUpdate.StopTimeUpdate & transit_realtime.TripUpdate.StopTimeUpdate.$Shape;
+       *   (properties?: transit_realtime.TripUpdate.StopTimeUpdate.$Properties): transit_realtime.TripUpdate.StopTimeUpdate;
+       * }}
        */
       StopTimeUpdate.create = function create(properties) {
         return new StopTimeUpdate(properties);
@@ -1792,12 +2188,14 @@ export const transit_realtime = ($root.transit_realtime = (() => {
        * @function encode
        * @memberof transit_realtime.TripUpdate.StopTimeUpdate
        * @static
-       * @param {transit_realtime.TripUpdate.IStopTimeUpdate} message StopTimeUpdate message or plain object to encode
+       * @param {transit_realtime.TripUpdate.StopTimeUpdate.$Properties} message StopTimeUpdate message or plain object to encode
        * @param {$protobuf.Writer} [writer] Writer to encode to
        * @returns {$protobuf.Writer} Writer
        */
-      StopTimeUpdate.encode = function encode(message, writer) {
+      StopTimeUpdate.encode = function encode(message, writer, _depth) {
         if (!writer) writer = $Writer.create();
+        if (_depth === undefined) _depth = 0;
+        if (_depth > $util.recursionLimit) throw Error("max depth exceeded");
         if (
           message.stopSequence != null &&
           Object.hasOwnProperty.call(message, "stopSequence")
@@ -1809,7 +2207,8 @@ export const transit_realtime = ($root.transit_realtime = (() => {
         )
           $root.transit_realtime.TripUpdate.StopTimeEvent.encode(
             message.arrival,
-            writer.uint32(/* id 2, wireType 2 =*/ 18).fork()
+            writer.uint32(/* id 2, wireType 2 =*/ 18).fork(),
+            _depth + 1
           ).ldelim();
         if (
           message.departure != null &&
@@ -1817,7 +2216,8 @@ export const transit_realtime = ($root.transit_realtime = (() => {
         )
           $root.transit_realtime.TripUpdate.StopTimeEvent.encode(
             message.departure,
-            writer.uint32(/* id 3, wireType 2 =*/ 26).fork()
+            writer.uint32(/* id 3, wireType 2 =*/ 26).fork(),
+            _depth + 1
           ).ldelim();
         if (
           message.stopId != null &&
@@ -1831,6 +2231,12 @@ export const transit_realtime = ($root.transit_realtime = (() => {
           writer
             .uint32(/* id 5, wireType 0 =*/ 40)
             .int32(message.scheduleRelationship);
+        if (
+          message.$unknowns != null &&
+          Object.hasOwnProperty.call(message, "$unknowns")
+        )
+          for (let i = 0; i < message.$unknowns.length; ++i)
+            writer.raw(message.$unknowns[i]);
         return writer;
       };
 
@@ -1839,7 +2245,7 @@ export const transit_realtime = ($root.transit_realtime = (() => {
        * @function encodeDelimited
        * @memberof transit_realtime.TripUpdate.StopTimeUpdate
        * @static
-       * @param {transit_realtime.TripUpdate.IStopTimeUpdate} message StopTimeUpdate message or plain object to encode
+       * @param {transit_realtime.TripUpdate.StopTimeUpdate.$Properties} message StopTimeUpdate message or plain object to encode
        * @param {$protobuf.Writer} [writer] Writer to encode to
        * @returns {$protobuf.Writer} Writer
        */
@@ -1847,7 +2253,10 @@ export const transit_realtime = ($root.transit_realtime = (() => {
         message,
         writer
       ) {
-        return this.encode(message, writer).ldelim();
+        return this.encode(
+          message,
+          writer && writer.len ? writer.fork() : writer
+        ).ldelim();
       };
 
       /**
@@ -1857,51 +2266,81 @@ export const transit_realtime = ($root.transit_realtime = (() => {
        * @static
        * @param {$protobuf.Reader|Uint8Array} reader Reader or buffer to decode from
        * @param {number} [length] Message length if known beforehand
-       * @returns {transit_realtime.TripUpdate.StopTimeUpdate} StopTimeUpdate
+       * @returns {transit_realtime.TripUpdate.StopTimeUpdate & transit_realtime.TripUpdate.StopTimeUpdate.$Shape} StopTimeUpdate
        * @throws {Error} If the payload is not a reader or valid buffer
        * @throws {$protobuf.util.ProtocolError} If required fields are missing
        */
-      StopTimeUpdate.decode = function decode(reader, length, error) {
+      StopTimeUpdate.decode = function decode(
+        reader,
+        length,
+        _end,
+        _depth,
+        _target
+      ) {
         if (!(reader instanceof $Reader)) reader = $Reader.create(reader);
+        if (_depth === undefined) _depth = 0;
+        if (_depth > $Reader.recursionLimit) throw Error("max depth exceeded");
         let end = length === undefined ? reader.len : reader.pos + length,
-          message = new $root.transit_realtime.TripUpdate.StopTimeUpdate();
+          message =
+            _target || new $root.transit_realtime.TripUpdate.StopTimeUpdate();
         while (reader.pos < end) {
-          let tag = reader.uint32();
-          if (tag === error) break;
-          switch (tag >>> 3) {
+          let start = reader.pos;
+          let tag = reader.tag();
+          if (tag === _end) {
+            _end = undefined;
+            break;
+          }
+          let wireType = tag & 7;
+          switch ((tag >>>= 3)) {
             case 1: {
+              if (wireType !== 0) break;
               message.stopSequence = reader.uint32();
-              break;
+              continue;
             }
             case 4: {
+              if (wireType !== 2) break;
               message.stopId = reader.string();
-              break;
+              continue;
             }
             case 2: {
+              if (wireType !== 2) break;
               message.arrival =
                 $root.transit_realtime.TripUpdate.StopTimeEvent.decode(
                   reader,
-                  reader.uint32()
+                  reader.uint32(),
+                  undefined,
+                  _depth + 1,
+                  message.arrival
                 );
-              break;
+              continue;
             }
             case 3: {
+              if (wireType !== 2) break;
               message.departure =
                 $root.transit_realtime.TripUpdate.StopTimeEvent.decode(
                   reader,
-                  reader.uint32()
+                  reader.uint32(),
+                  undefined,
+                  _depth + 1,
+                  message.departure
                 );
-              break;
+              continue;
             }
             case 5: {
+              if (wireType !== 0) break;
               message.scheduleRelationship = reader.int32();
-              break;
+              continue;
             }
-            default:
-              reader.skipType(tag & 7);
-              break;
+          }
+          reader.skipType(wireType, _depth, tag);
+          if (!reader.discardUnknown) {
+            $util.makeProp(message, "$unknowns", false);
+            (message.$unknowns || (message.$unknowns = [])).push(
+              reader.raw(start, reader.pos)
+            );
           }
         }
+        if (_end !== undefined) throw Error("missing end group");
         return message;
       };
 
@@ -1911,7 +2350,7 @@ export const transit_realtime = ($root.transit_realtime = (() => {
        * @memberof transit_realtime.TripUpdate.StopTimeUpdate
        * @static
        * @param {$protobuf.Reader|Uint8Array} reader Reader or buffer to decode from
-       * @returns {transit_realtime.TripUpdate.StopTimeUpdate} StopTimeUpdate
+       * @returns {transit_realtime.TripUpdate.StopTimeUpdate & transit_realtime.TripUpdate.StopTimeUpdate.$Shape} StopTimeUpdate
        * @throws {Error} If the payload is not a reader or valid buffer
        * @throws {$protobuf.util.ProtocolError} If required fields are missing
        */
@@ -1928,9 +2367,11 @@ export const transit_realtime = ($root.transit_realtime = (() => {
        * @param {Object.<string,*>} message Plain object to verify
        * @returns {string|null} `null` if valid, otherwise the reason why it is not
        */
-      StopTimeUpdate.verify = function verify(message) {
+      StopTimeUpdate.verify = function verify(message, _depth) {
         if (typeof message !== "object" || message === null)
           return "object expected";
+        if (_depth === undefined) _depth = 0;
+        if (_depth > $util.recursionLimit) return "max depth exceeded";
         if (
           message.stopSequence != null &&
           message.hasOwnProperty("stopSequence")
@@ -1941,13 +2382,15 @@ export const transit_realtime = ($root.transit_realtime = (() => {
           if (!$util.isString(message.stopId)) return "stopId: string expected";
         if (message.arrival != null && message.hasOwnProperty("arrival")) {
           let error = $root.transit_realtime.TripUpdate.StopTimeEvent.verify(
-            message.arrival
+            message.arrival,
+            _depth + 1
           );
           if (error) return "arrival." + error;
         }
         if (message.departure != null && message.hasOwnProperty("departure")) {
           let error = $root.transit_realtime.TripUpdate.StopTimeEvent.verify(
-            message.departure
+            message.departure,
+            _depth + 1
           );
           if (error) return "departure." + error;
         }
@@ -1974,31 +2417,39 @@ export const transit_realtime = ($root.transit_realtime = (() => {
        * @param {Object.<string,*>} object Plain object
        * @returns {transit_realtime.TripUpdate.StopTimeUpdate} StopTimeUpdate
        */
-      StopTimeUpdate.fromObject = function fromObject(object) {
+      StopTimeUpdate.fromObject = function fromObject(object, _depth) {
         if (object instanceof $root.transit_realtime.TripUpdate.StopTimeUpdate)
           return object;
+        if (!$util.isObject(object))
+          throw TypeError(
+            ".transit_realtime.TripUpdate.StopTimeUpdate: object expected"
+          );
+        if (_depth === undefined) _depth = 0;
+        if (_depth > $util.recursionLimit) throw Error("max depth exceeded");
         let message = new $root.transit_realtime.TripUpdate.StopTimeUpdate();
         if (object.stopSequence != null)
           message.stopSequence = object.stopSequence >>> 0;
         if (object.stopId != null) message.stopId = String(object.stopId);
         if (object.arrival != null) {
-          if (typeof object.arrival !== "object")
+          if (!$util.isObject(object.arrival))
             throw TypeError(
               ".transit_realtime.TripUpdate.StopTimeUpdate.arrival: object expected"
             );
           message.arrival =
             $root.transit_realtime.TripUpdate.StopTimeEvent.fromObject(
-              object.arrival
+              object.arrival,
+              _depth + 1
             );
         }
         if (object.departure != null) {
-          if (typeof object.departure !== "object")
+          if (!$util.isObject(object.departure))
             throw TypeError(
               ".transit_realtime.TripUpdate.StopTimeUpdate.departure: object expected"
             );
           message.departure =
             $root.transit_realtime.TripUpdate.StopTimeEvent.fromObject(
-              object.departure
+              object.departure,
+              _depth + 1
             );
         }
         switch (object.scheduleRelationship) {
@@ -2033,8 +2484,10 @@ export const transit_realtime = ($root.transit_realtime = (() => {
        * @param {$protobuf.IConversionOptions} [options] Conversion options
        * @returns {Object.<string,*>} Plain object
        */
-      StopTimeUpdate.toObject = function toObject(message, options) {
+      StopTimeUpdate.toObject = function toObject(message, options, _depth) {
         if (!options) options = {};
+        if (_depth === undefined) _depth = 0;
+        if (_depth > $util.recursionLimit) throw Error("max depth exceeded");
         let object = {};
         if (options.defaults) {
           object.stopSequence = 0;
@@ -2053,13 +2506,15 @@ export const transit_realtime = ($root.transit_realtime = (() => {
           object.arrival =
             $root.transit_realtime.TripUpdate.StopTimeEvent.toObject(
               message.arrival,
-              options
+              options,
+              _depth + 1
             );
         if (message.departure != null && message.hasOwnProperty("departure"))
           object.departure =
             $root.transit_realtime.TripUpdate.StopTimeEvent.toObject(
               message.departure,
-              options
+              options,
+              _depth + 1
             );
         if (message.stopId != null && message.hasOwnProperty("stopId"))
           object.stopId = message.stopId;
@@ -2091,18 +2546,16 @@ export const transit_realtime = ($root.transit_realtime = (() => {
       };
 
       /**
-       * Gets the default type url for StopTimeUpdate
+       * Gets the type url for StopTimeUpdate
        * @function getTypeUrl
        * @memberof transit_realtime.TripUpdate.StopTimeUpdate
        * @static
-       * @param {string} [typeUrlPrefix] your custom typeUrlPrefix(default "type.googleapis.com")
-       * @returns {string} The default type url
+       * @param {string} [prefix] Custom type url prefix, defaults to `"type.googleapis.com"`
+       * @returns {string} The type url
        */
-      StopTimeUpdate.getTypeUrl = function getTypeUrl(typeUrlPrefix) {
-        if (typeUrlPrefix === undefined) {
-          typeUrlPrefix = "type.googleapis.com";
-        }
-        return typeUrlPrefix + "/transit_realtime.TripUpdate.StopTimeUpdate";
+      StopTimeUpdate.getTypeUrl = function getTypeUrl(prefix) {
+        if (prefix === undefined) prefix = "type.googleapis.com";
+        return prefix + "/transit_realtime.TripUpdate.StopTimeUpdate";
       };
 
       /**
@@ -2131,36 +2584,50 @@ export const transit_realtime = ($root.transit_realtime = (() => {
   transit_realtime.VehiclePosition = (function () {
     /**
      * Properties of a VehiclePosition.
-     * @memberof transit_realtime
-     * @interface IVehiclePosition
-     * @property {transit_realtime.ITripDescriptor|null} [trip] VehiclePosition trip
-     * @property {transit_realtime.IVehicleDescriptor|null} [vehicle] VehiclePosition vehicle
-     * @property {transit_realtime.IPosition|null} [position] VehiclePosition position
+     * @typedef {Object} transit_realtime.VehiclePosition.$Properties
+     * @property {transit_realtime.TripDescriptor.$Properties|null} [trip] VehiclePosition trip
+     * @property {transit_realtime.VehicleDescriptor.$Properties|null} [vehicle] VehiclePosition vehicle
+     * @property {transit_realtime.Position.$Properties|null} [position] VehiclePosition position
      * @property {number|null} [currentStopSequence] VehiclePosition currentStopSequence
      * @property {string|null} [stopId] VehiclePosition stopId
      * @property {transit_realtime.VehiclePosition.VehicleStopStatus|null} [currentStatus] VehiclePosition currentStatus
      * @property {number|Long|null} [timestamp] VehiclePosition timestamp
      * @property {transit_realtime.VehiclePosition.CongestionLevel|null} [congestionLevel] VehiclePosition congestionLevel
      * @property {transit_realtime.VehiclePosition.OccupancyStatus|null} [occupancyStatus] VehiclePosition occupancyStatus
+     * @property {Array.<Uint8Array>} [$unknowns] Unknown fields preserved while decoding
+     */
+
+    /**
+     * Properties of a VehiclePosition.
+     * @memberof transit_realtime
+     * @interface IVehiclePosition
+     * @augments transit_realtime.VehiclePosition.$Properties
+     * @deprecated Use transit_realtime.VehiclePosition.$Properties instead.
+     */
+
+    /**
+     * Shape of a VehiclePosition.
+     * @typedef {transit_realtime.VehiclePosition.$Properties} transit_realtime.VehiclePosition.$Shape
      */
 
     /**
      * Constructs a new VehiclePosition.
      * @memberof transit_realtime
      * @classdesc Represents a VehiclePosition.
-     * @implements IVehiclePosition
      * @constructor
-     * @param {transit_realtime.IVehiclePosition=} [properties] Properties to set
+     * @param {transit_realtime.VehiclePosition.$Properties=} [properties] Properties to set
+     * @property {Array.<Uint8Array>} [$unknowns] Unknown fields preserved while decoding
      */
     function VehiclePosition(properties) {
       if (properties)
         for (let keys = Object.keys(properties), i = 0; i < keys.length; ++i)
-          if (properties[keys[i]] != null) this[keys[i]] = properties[keys[i]];
+          if (properties[keys[i]] != null && keys[i] !== "__proto__")
+            this[keys[i]] = properties[keys[i]];
     }
 
     /**
      * VehiclePosition trip.
-     * @member {transit_realtime.ITripDescriptor|null|undefined} trip
+     * @member {transit_realtime.TripDescriptor.$Properties|null|undefined} trip
      * @memberof transit_realtime.VehiclePosition
      * @instance
      */
@@ -2168,7 +2635,7 @@ export const transit_realtime = ($root.transit_realtime = (() => {
 
     /**
      * VehiclePosition vehicle.
-     * @member {transit_realtime.IVehicleDescriptor|null|undefined} vehicle
+     * @member {transit_realtime.VehicleDescriptor.$Properties|null|undefined} vehicle
      * @memberof transit_realtime.VehiclePosition
      * @instance
      */
@@ -2176,7 +2643,7 @@ export const transit_realtime = ($root.transit_realtime = (() => {
 
     /**
      * VehiclePosition position.
-     * @member {transit_realtime.IPosition|null|undefined} position
+     * @member {transit_realtime.Position.$Properties|null|undefined} position
      * @memberof transit_realtime.VehiclePosition
      * @instance
      */
@@ -2237,8 +2704,12 @@ export const transit_realtime = ($root.transit_realtime = (() => {
      * @function create
      * @memberof transit_realtime.VehiclePosition
      * @static
-     * @param {transit_realtime.IVehiclePosition=} [properties] Properties to set
+     * @param {transit_realtime.VehiclePosition.$Properties=} [properties] Properties to set
      * @returns {transit_realtime.VehiclePosition} VehiclePosition instance
+     * @type {{
+     *   (properties: transit_realtime.VehiclePosition.$Shape): transit_realtime.VehiclePosition & transit_realtime.VehiclePosition.$Shape;
+     *   (properties?: transit_realtime.VehiclePosition.$Properties): transit_realtime.VehiclePosition;
+     * }}
      */
     VehiclePosition.create = function create(properties) {
       return new VehiclePosition(properties);
@@ -2249,16 +2720,19 @@ export const transit_realtime = ($root.transit_realtime = (() => {
      * @function encode
      * @memberof transit_realtime.VehiclePosition
      * @static
-     * @param {transit_realtime.IVehiclePosition} message VehiclePosition message or plain object to encode
+     * @param {transit_realtime.VehiclePosition.$Properties} message VehiclePosition message or plain object to encode
      * @param {$protobuf.Writer} [writer] Writer to encode to
      * @returns {$protobuf.Writer} Writer
      */
-    VehiclePosition.encode = function encode(message, writer) {
+    VehiclePosition.encode = function encode(message, writer, _depth) {
       if (!writer) writer = $Writer.create();
+      if (_depth === undefined) _depth = 0;
+      if (_depth > $util.recursionLimit) throw Error("max depth exceeded");
       if (message.trip != null && Object.hasOwnProperty.call(message, "trip"))
         $root.transit_realtime.TripDescriptor.encode(
           message.trip,
-          writer.uint32(/* id 1, wireType 2 =*/ 10).fork()
+          writer.uint32(/* id 1, wireType 2 =*/ 10).fork(),
+          _depth + 1
         ).ldelim();
       if (
         message.position != null &&
@@ -2266,7 +2740,8 @@ export const transit_realtime = ($root.transit_realtime = (() => {
       )
         $root.transit_realtime.Position.encode(
           message.position,
-          writer.uint32(/* id 2, wireType 2 =*/ 18).fork()
+          writer.uint32(/* id 2, wireType 2 =*/ 18).fork(),
+          _depth + 1
         ).ldelim();
       if (
         message.currentStopSequence != null &&
@@ -2303,7 +2778,8 @@ export const transit_realtime = ($root.transit_realtime = (() => {
       )
         $root.transit_realtime.VehicleDescriptor.encode(
           message.vehicle,
-          writer.uint32(/* id 8, wireType 2 =*/ 66).fork()
+          writer.uint32(/* id 8, wireType 2 =*/ 66).fork(),
+          _depth + 1
         ).ldelim();
       if (
         message.occupancyStatus != null &&
@@ -2312,6 +2788,12 @@ export const transit_realtime = ($root.transit_realtime = (() => {
         writer
           .uint32(/* id 9, wireType 0 =*/ 72)
           .int32(message.occupancyStatus);
+      if (
+        message.$unknowns != null &&
+        Object.hasOwnProperty.call(message, "$unknowns")
+      )
+        for (let i = 0; i < message.$unknowns.length; ++i)
+          writer.raw(message.$unknowns[i]);
       return writer;
     };
 
@@ -2320,7 +2802,7 @@ export const transit_realtime = ($root.transit_realtime = (() => {
      * @function encodeDelimited
      * @memberof transit_realtime.VehiclePosition
      * @static
-     * @param {transit_realtime.IVehiclePosition} message VehiclePosition message or plain object to encode
+     * @param {transit_realtime.VehiclePosition.$Properties} message VehiclePosition message or plain object to encode
      * @param {$protobuf.Writer} [writer] Writer to encode to
      * @returns {$protobuf.Writer} Writer
      */
@@ -2328,7 +2810,10 @@ export const transit_realtime = ($root.transit_realtime = (() => {
       message,
       writer
     ) {
-      return this.encode(message, writer).ldelim();
+      return this.encode(
+        message,
+        writer && writer.len ? writer.fork() : writer
+      ).ldelim();
     };
 
     /**
@@ -2338,68 +2823,104 @@ export const transit_realtime = ($root.transit_realtime = (() => {
      * @static
      * @param {$protobuf.Reader|Uint8Array} reader Reader or buffer to decode from
      * @param {number} [length] Message length if known beforehand
-     * @returns {transit_realtime.VehiclePosition} VehiclePosition
+     * @returns {transit_realtime.VehiclePosition & transit_realtime.VehiclePosition.$Shape} VehiclePosition
      * @throws {Error} If the payload is not a reader or valid buffer
      * @throws {$protobuf.util.ProtocolError} If required fields are missing
      */
-    VehiclePosition.decode = function decode(reader, length, error) {
+    VehiclePosition.decode = function decode(
+      reader,
+      length,
+      _end,
+      _depth,
+      _target
+    ) {
       if (!(reader instanceof $Reader)) reader = $Reader.create(reader);
+      if (_depth === undefined) _depth = 0;
+      if (_depth > $Reader.recursionLimit) throw Error("max depth exceeded");
       let end = length === undefined ? reader.len : reader.pos + length,
-        message = new $root.transit_realtime.VehiclePosition();
+        message = _target || new $root.transit_realtime.VehiclePosition();
       while (reader.pos < end) {
-        let tag = reader.uint32();
-        if (tag === error) break;
-        switch (tag >>> 3) {
+        let start = reader.pos;
+        let tag = reader.tag();
+        if (tag === _end) {
+          _end = undefined;
+          break;
+        }
+        let wireType = tag & 7;
+        switch ((tag >>>= 3)) {
           case 1: {
+            if (wireType !== 2) break;
             message.trip = $root.transit_realtime.TripDescriptor.decode(
               reader,
-              reader.uint32()
+              reader.uint32(),
+              undefined,
+              _depth + 1,
+              message.trip
             );
-            break;
+            continue;
           }
           case 8: {
+            if (wireType !== 2) break;
             message.vehicle = $root.transit_realtime.VehicleDescriptor.decode(
               reader,
-              reader.uint32()
+              reader.uint32(),
+              undefined,
+              _depth + 1,
+              message.vehicle
             );
-            break;
+            continue;
           }
           case 2: {
+            if (wireType !== 2) break;
             message.position = $root.transit_realtime.Position.decode(
               reader,
-              reader.uint32()
+              reader.uint32(),
+              undefined,
+              _depth + 1,
+              message.position
             );
-            break;
+            continue;
           }
           case 3: {
+            if (wireType !== 0) break;
             message.currentStopSequence = reader.uint32();
-            break;
+            continue;
           }
           case 7: {
+            if (wireType !== 2) break;
             message.stopId = reader.string();
-            break;
+            continue;
           }
           case 4: {
+            if (wireType !== 0) break;
             message.currentStatus = reader.int32();
-            break;
+            continue;
           }
           case 5: {
+            if (wireType !== 0) break;
             message.timestamp = reader.uint64();
-            break;
+            continue;
           }
           case 6: {
+            if (wireType !== 0) break;
             message.congestionLevel = reader.int32();
-            break;
+            continue;
           }
           case 9: {
+            if (wireType !== 0) break;
             message.occupancyStatus = reader.int32();
-            break;
+            continue;
           }
-          default:
-            reader.skipType(tag & 7);
-            break;
+        }
+        reader.skipType(wireType, _depth, tag);
+        if (!reader.discardUnknown) {
+          $util.makeProp(message, "$unknowns", false);
+          (message.$unknowns || (message.$unknowns = [])).push(
+            reader.raw(start, reader.pos)
+          );
         }
       }
+      if (_end !== undefined) throw Error("missing end group");
       return message;
     };
 
@@ -2409,7 +2930,7 @@ export const transit_realtime = ($root.transit_realtime = (() => {
      * @memberof transit_realtime.VehiclePosition
      * @static
      * @param {$protobuf.Reader|Uint8Array} reader Reader or buffer to decode from
-     * @returns {transit_realtime.VehiclePosition} VehiclePosition
+     * @returns {transit_realtime.VehiclePosition & transit_realtime.VehiclePosition.$Shape} VehiclePosition
      * @throws {Error} If the payload is not a reader or valid buffer
      * @throws {$protobuf.util.ProtocolError} If required fields are missing
      */
@@ -2426,21 +2947,30 @@ export const transit_realtime = ($root.transit_realtime = (() => {
      * @param {Object.<string,*>} message Plain object to verify
      * @returns {string|null} `null` if valid, otherwise the reason why it is not
      */
-    VehiclePosition.verify = function verify(message) {
+    VehiclePosition.verify = function verify(message, _depth) {
       if (typeof message !== "object" || message === null)
         return "object expected";
+      if (_depth === undefined) _depth = 0;
+      if (_depth > $util.recursionLimit) return "max depth exceeded";
       if (message.trip != null && message.hasOwnProperty("trip")) {
-        let error = $root.transit_realtime.TripDescriptor.verify(message.trip);
+        let error = $root.transit_realtime.TripDescriptor.verify(
+          message.trip,
+          _depth + 1
+        );
         if (error) return "trip." + error;
       }
       if (message.vehicle != null && message.hasOwnProperty("vehicle")) {
         let error = $root.transit_realtime.VehicleDescriptor.verify(
-          message.vehicle
+          message.vehicle,
+          _depth + 1
         );
         if (error) return "vehicle." + error;
       }
       if (message.position != null && message.hasOwnProperty("position")) {
-        let error = $root.transit_realtime.Position.verify(message.position);
+        let error = $root.transit_realtime.Position.verify(
+          message.position,
+          _depth + 1
+        );
         if (error) return "position." + error;
       }
       if (
@@ -2514,35 +3044,42 @@ export const transit_realtime = ($root.transit_realtime = (() => {
      * @param {Object.<string,*>} object Plain object
      * @returns {transit_realtime.VehiclePosition} VehiclePosition
      */
-    VehiclePosition.fromObject = function fromObject(object) {
+    VehiclePosition.fromObject = function fromObject(object, _depth) {
       if (object instanceof $root.transit_realtime.VehiclePosition)
         return object;
+      if (!$util.isObject(object))
+        throw TypeError(".transit_realtime.VehiclePosition: object expected");
+      if (_depth === undefined) _depth = 0;
+      if (_depth > $util.recursionLimit) throw Error("max depth exceeded");
       let message = new $root.transit_realtime.VehiclePosition();
       if (object.trip != null) {
-        if (typeof object.trip !== "object")
+        if (!$util.isObject(object.trip))
           throw TypeError(
             ".transit_realtime.VehiclePosition.trip: object expected"
           );
         message.trip = $root.transit_realtime.TripDescriptor.fromObject(
-          object.trip
+          object.trip,
+          _depth + 1
         );
       }
       if (object.vehicle != null) {
-        if (typeof object.vehicle !== "object")
+        if (!$util.isObject(object.vehicle))
           throw TypeError(
             ".transit_realtime.VehiclePosition.vehicle: object expected"
           );
         message.vehicle = $root.transit_realtime.VehicleDescriptor.fromObject(
-          object.vehicle
+          object.vehicle,
+          _depth + 1
         );
       }
       if (object.position != null) {
-        if (typeof object.position !== "object")
+        if (!$util.isObject(object.position))
           throw TypeError(
             ".transit_realtime.VehiclePosition.position: object expected"
           );
         message.position = $root.transit_realtime.Position.fromObject(
-          object.position
+          object.position,
+          _depth + 1
         );
       }
       if (object.currentStopSequence != null)
@@ -2570,9 +3107,7 @@ export const transit_realtime = ($root.transit_realtime = (() => {
       }
       if (object.timestamp != null)
         if ($util.Long)
-          (message.timestamp = $util.Long.fromValue(
-            object.timestamp
-          )).unsigned = true;
+          message.timestamp = $util.Long.fromValue(object.timestamp, true);
         else if (typeof object.timestamp === "string")
           message.timestamp = parseInt(object.timestamp, 10);
         else if (typeof object.timestamp === "number")
@@ -2658,8 +3193,10 @@ export const transit_realtime = ($root.transit_realtime = (() => {
      * @param {$protobuf.IConversionOptions} [options] Conversion options
      * @returns {Object.<string,*>} Plain object
      */
-    VehiclePosition.toObject = function toObject(message, options) {
+    VehiclePosition.toObject = function toObject(message, options, _depth) {
       if (!options) options = {};
+      if (_depth === undefined) _depth = 0;
+      if (_depth > $util.recursionLimit) throw Error("max depth exceeded");
       let object = {};
       if (options.defaults) {
         object.trip = null;
@@ -2673,8 +3210,16 @@ export const transit_realtime = ($root.transit_realtime = (() => {
               ? long.toString()
               : options.longs === Number
               ? long.toNumber()
+              : typeof BigInt !== "undefined" && options.longs === BigInt
+              ? long.toBigInt()
               : long;
-        } else object.timestamp = options.longs === String ? "0" : 0;
+        } else
+          object.timestamp =
+            options.longs === String
+              ? "0"
+              : typeof BigInt !== "undefined" && options.longs === BigInt
+              ? BigInt("0")
+              : 0;
         object.congestionLevel =
           options.enums === String ? "UNKNOWN_CONGESTION_LEVEL" : 0;
         object.stopId = "";
@@ -2684,12 +3229,14 @@ export const transit_realtime = ($root.transit_realtime = (() => {
       if (message.trip != null && message.hasOwnProperty("trip"))
         object.trip = $root.transit_realtime.TripDescriptor.toObject(
           message.trip,
-          options
+          options,
+          _depth + 1
         );
       if (message.position != null && message.hasOwnProperty("position"))
         object.position = $root.transit_realtime.Position.toObject(
           message.position,
-          options
+          options,
+          _depth + 1
         );
       if (
         message.currentStopSequence != null &&
@@ -2711,7 +3258,16 @@ export const transit_realtime = ($root.transit_realtime = (() => {
                 ]
             : message.currentStatus;
       if (message.timestamp != null && message.hasOwnProperty("timestamp"))
-        if (typeof message.timestamp === "number")
+        if (typeof BigInt !== "undefined" && options.longs === BigInt)
+          object.timestamp =
+            typeof message.timestamp === "number"
+              ? BigInt(message.timestamp)
+              : $util.Long.fromBits(
+                  message.timestamp.low >>> 0,
+                  message.timestamp.high >>> 0,
+                  true
+                ).toBigInt();
+        else if (typeof message.timestamp === "number")
           object.timestamp =
             options.longs === String
               ? String(message.timestamp)
@@ -2745,7 +3301,8 @@ export const transit_realtime = ($root.transit_realtime = (() => {
       if (message.vehicle != null && message.hasOwnProperty("vehicle"))
         object.vehicle = $root.transit_realtime.VehicleDescriptor.toObject(
           message.vehicle,
-          options
+          options,
+          _depth + 1
         );
       if (
         message.occupancyStatus != null &&
@@ -2776,18 +3333,16 @@ export const transit_realtime = ($root.transit_realtime = (() => {
     };
 
     /**
-     * Gets the default type url for VehiclePosition
+     * Gets the type url for VehiclePosition
      * @function getTypeUrl
      * @memberof transit_realtime.VehiclePosition
      * @static
-     * @param {string} [typeUrlPrefix] your custom typeUrlPrefix(default "type.googleapis.com")
-     * @returns {string} The default type url
+     * @param {string} [prefix] Custom type url prefix, defaults to `"type.googleapis.com"`
+     * @returns {string} The type url
      */
-    VehiclePosition.getTypeUrl = function getTypeUrl(typeUrlPrefix) {
-      if (typeUrlPrefix === undefined) {
-        typeUrlPrefix = "type.googleapis.com";
-      }
-      return typeUrlPrefix + "/transit_realtime.VehiclePosition";
+    VehiclePosition.getTypeUrl = function getTypeUrl(prefix) {
+      if (prefix === undefined) prefix = "type.googleapis.com";
+      return prefix + "/transit_realtime.VehiclePosition";
     };
 
     /**
@@ -2859,36 +3414,50 @@ export const transit_realtime = ($root.transit_realtime = (() => {
   transit_realtime.Alert = (function () {
     /**
      * Properties of an Alert.
-     * @memberof transit_realtime
-     * @interface IAlert
-     * @property {Array.<transit_realtime.ITimeRange>|null} [activePeriod] Alert activePeriod
-     * @property {Array.<transit_realtime.IEntitySelector>|null} [informedEntity] Alert informedEntity
+     * @typedef {Object} transit_realtime.Alert.$Properties
+     * @property {Array.<transit_realtime.TimeRange.$Properties>|null} [activePeriod] Alert activePeriod
+     * @property {Array.<transit_realtime.EntitySelector.$Properties>|null} [informedEntity] Alert informedEntity
      * @property {transit_realtime.Alert.Cause|null} [cause] Alert cause
      * @property {transit_realtime.Alert.Effect|null} [effect] Alert effect
-     * @property {transit_realtime.ITranslatedString|null} [url] Alert url
-     * @property {transit_realtime.ITranslatedString|null} [headerText] Alert headerText
-     * @property {transit_realtime.ITranslatedString|null} [descriptionText] Alert descriptionText
+     * @property {transit_realtime.TranslatedString.$Properties|null} [url] Alert url
+     * @property {transit_realtime.TranslatedString.$Properties|null} [headerText] Alert headerText
+     * @property {transit_realtime.TranslatedString.$Properties|null} [descriptionText] Alert descriptionText
+     * @property {Array.<Uint8Array>} [$unknowns] Unknown fields preserved while decoding
+     */
+
+    /**
+     * Properties of an Alert.
+     * @memberof transit_realtime
+     * @interface IAlert
+     * @augments transit_realtime.Alert.$Properties
+     * @deprecated Use transit_realtime.Alert.$Properties instead.
+     */
+
+    /**
+     * Shape of an Alert.
+     * @typedef {transit_realtime.Alert.$Properties} transit_realtime.Alert.$Shape
      */
 
     /**
      * Constructs a new Alert.
      * @memberof transit_realtime
      * @classdesc Represents an Alert.
-     * @implements IAlert
      * @constructor
-     * @param {transit_realtime.IAlert=} [properties] Properties to set
+     * @param {transit_realtime.Alert.$Properties=} [properties] Properties to set
+     * @property {Array.<Uint8Array>} [$unknowns] Unknown fields preserved while decoding
      */
     function Alert(properties) {
       this.activePeriod = [];
       this.informedEntity = [];
       if (properties)
         for (let keys = Object.keys(properties), i = 0; i < keys.length; ++i)
-          if (properties[keys[i]] != null) this[keys[i]] = properties[keys[i]];
+          if (properties[keys[i]] != null && keys[i] !== "__proto__")
+            this[keys[i]] = properties[keys[i]];
     }
 
     /**
      * Alert activePeriod.
-     * @member {Array.<transit_realtime.ITimeRange>} activePeriod
+     * @member {Array.<transit_realtime.TimeRange.$Properties>} activePeriod
      * @memberof transit_realtime.Alert
      * @instance
      */
@@ -2896,7 +3465,7 @@ export const transit_realtime = ($root.transit_realtime = (() => {
 
     /**
      * Alert informedEntity.
-     * @member {Array.<transit_realtime.IEntitySelector>} informedEntity
+     * @member {Array.<transit_realtime.EntitySelector.$Properties>} informedEntity
      * @memberof transit_realtime.Alert
      * @instance
      */
@@ -2920,7 +3489,7 @@ export const transit_realtime = ($root.transit_realtime = (() => {
 
     /**
      * Alert url.
-     * @member {transit_realtime.ITranslatedString|null|undefined} url
+     * @member {transit_realtime.TranslatedString.$Properties|null|undefined} url
      * @memberof transit_realtime.Alert
      * @instance
      */
@@ -2928,7 +3497,7 @@ export const transit_realtime = ($root.transit_realtime = (() => {
 
     /**
      * Alert headerText.
-     * @member {transit_realtime.ITranslatedString|null|undefined} headerText
+     * @member {transit_realtime.TranslatedString.$Properties|null|undefined} headerText
      * @memberof transit_realtime.Alert
      * @instance
      */
@@ -2936,7 +3505,7 @@ export const transit_realtime = ($root.transit_realtime = (() => {
 
     /**
      * Alert descriptionText.
-     * @member {transit_realtime.ITranslatedString|null|undefined} descriptionText
+     * @member {transit_realtime.TranslatedString.$Properties|null|undefined} descriptionText
      * @memberof transit_realtime.Alert
      * @instance
      */
@@ -2947,8 +3516,12 @@ export const transit_realtime = ($root.transit_realtime = (() => {
      * @function create
      * @memberof transit_realtime.Alert
      * @static
-     * @param {transit_realtime.IAlert=} [properties] Properties to set
+     * @param {transit_realtime.Alert.$Properties=} [properties] Properties to set
      * @returns {transit_realtime.Alert} Alert instance
+     * @type {{
+     *   (properties: transit_realtime.Alert.$Shape): transit_realtime.Alert & transit_realtime.Alert.$Shape;
+     *   (properties?: transit_realtime.Alert.$Properties): transit_realtime.Alert;
+     * }}
      */
     Alert.create = function create(properties) {
       return new Alert(properties);
@@ -2959,23 +3532,27 @@ export const transit_realtime = ($root.transit_realtime = (() => {
      * @function encode
      * @memberof transit_realtime.Alert
      * @static
-     * @param {transit_realtime.IAlert} message Alert message or plain object to encode
+     * @param {transit_realtime.Alert.$Properties} message Alert message or plain object to encode
      * @param {$protobuf.Writer} [writer] Writer to encode to
      * @returns {$protobuf.Writer} Writer
      */
-    Alert.encode = function encode(message, writer) {
+    Alert.encode = function encode(message, writer, _depth) {
       if (!writer) writer = $Writer.create();
+      if (_depth === undefined) _depth = 0;
+      if (_depth > $util.recursionLimit) throw Error("max depth exceeded");
       if (message.activePeriod != null && message.activePeriod.length)
         for (let i = 0; i < message.activePeriod.length; ++i)
           $root.transit_realtime.TimeRange.encode(
             message.activePeriod[i],
-            writer.uint32(/* id 1, wireType 2 =*/ 10).fork()
+            writer.uint32(/* id 1, wireType 2 =*/ 10).fork(),
+            _depth + 1
           ).ldelim();
       if (message.informedEntity != null && message.informedEntity.length)
         for (let i = 0; i < message.informedEntity.length; ++i)
           $root.transit_realtime.EntitySelector.encode(
             message.informedEntity[i],
-            writer.uint32(/* id 5, wireType 2 =*/ 42).fork()
+            writer.uint32(/* id 5, wireType 2 =*/ 42).fork(),
+            _depth + 1
           ).ldelim();
       if (message.cause != null && Object.hasOwnProperty.call(message, "cause"))
         writer.uint32(/* id 6, wireType 0 =*/ 48).int32(message.cause);
@@ -2987,7 +3564,8 @@ export const transit_realtime = ($root.transit_realtime = (() => {
       if (message.url != null && Object.hasOwnProperty.call(message, "url"))
         $root.transit_realtime.TranslatedString.encode(
           message.url,
-          writer.uint32(/* id 8, wireType 2 =*/ 66).fork()
+          writer.uint32(/* id 8, wireType 2 =*/ 66).fork(),
+          _depth + 1
         ).ldelim();
       if (
         message.headerText != null &&
@@ -2995,7 +3573,8 @@ export const transit_realtime = ($root.transit_realtime = (() => {
       )
         $root.transit_realtime.TranslatedString.encode(
           message.headerText,
-          writer.uint32(/* id 10, wireType 2 =*/ 82).fork()
+          writer.uint32(/* id 10, wireType 2 =*/ 82).fork(),
+          _depth + 1
         ).ldelim();
       if (
         message.descriptionText != null &&
@@ -3003,8 +3582,15 @@ export const transit_realtime = ($root.transit_realtime = (() => {
       )
         $root.transit_realtime.TranslatedString.encode(
           message.descriptionText,
-          writer.uint32(/* id 11, wireType 2 =*/ 90).fork()
+          writer.uint32(/* id 11, wireType 2 =*/ 90).fork(),
+          _depth + 1
         ).ldelim();
+      if (
+        message.$unknowns != null &&
+        Object.hasOwnProperty.call(message, "$unknowns")
+      )
+        for (let i = 0; i < message.$unknowns.length; ++i)
+          writer.raw(message.$unknowns[i]);
       return writer;
     };
 
@@ -3013,12 +3599,15 @@ export const transit_realtime = ($root.transit_realtime = (() => {
      * @function encodeDelimited
      * @memberof transit_realtime.Alert
      * @static
-     * @param {transit_realtime.IAlert} message Alert message or plain object to encode
+     * @param {transit_realtime.Alert.$Properties} message Alert message or plain object to encode
      * @param {$protobuf.Writer} [writer] Writer to encode to
      * @returns {$protobuf.Writer} Writer
      */
     Alert.encodeDelimited = function encodeDelimited(message, writer) {
-      return this.encode(message, writer).ldelim();
+      return this.encode(
+        message,
+        writer && writer.len ? writer.fork() : writer
+      ).ldelim();
     };
 
     /**
@@ -3028,72 +3617,107 @@ export const transit_realtime = ($root.transit_realtime = (() => {
      * @static
      * @param {$protobuf.Reader|Uint8Array} reader Reader or buffer to decode from
      * @param {number} [length] Message length if known beforehand
-     * @returns {transit_realtime.Alert} Alert
+     * @returns {transit_realtime.Alert & transit_realtime.Alert.$Shape} Alert
      * @throws {Error} If the payload is not a reader or valid buffer
      * @throws {$protobuf.util.ProtocolError} If required fields are missing
      */
-    Alert.decode = function decode(reader, length, error) {
+    Alert.decode = function decode(reader, length, _end, _depth, _target) {
       if (!(reader instanceof $Reader)) reader = $Reader.create(reader);
+      if (_depth === undefined) _depth = 0;
+      if (_depth > $Reader.recursionLimit) throw Error("max depth exceeded");
       let end = length === undefined ? reader.len : reader.pos + length,
-        message = new $root.transit_realtime.Alert();
+        message = _target || new $root.transit_realtime.Alert();
       while (reader.pos < end) {
-        let tag = reader.uint32();
-        if (tag === error) break;
-        switch (tag >>> 3) {
+        let start = reader.pos;
+        let tag = reader.tag();
+        if (tag === _end) {
+          _end = undefined;
+          break;
+        }
+        let wireType = tag & 7;
+        switch ((tag >>>= 3)) {
           case 1: {
+            if (wireType !== 2) break;
             if (!(message.activePeriod && message.activePeriod.length))
               message.activePeriod = [];
             message.activePeriod.push(
-              $root.transit_realtime.TimeRange.decode(reader, reader.uint32())
+              $root.transit_realtime.TimeRange.decode(
+                reader,
+                reader.uint32(),
+                undefined,
+                _depth + 1
+              )
             );
-            break;
+            continue;
           }
           case 5: {
+            if (wireType !== 2) break;
             if (!(message.informedEntity && message.informedEntity.length))
               message.informedEntity = [];
             message.informedEntity.push(
               $root.transit_realtime.EntitySelector.decode(
                 reader,
-                reader.uint32()
+                reader.uint32(),
+                undefined,
+                _depth + 1
               )
             );
-            break;
+            continue;
           }
           case 6: {
+            if (wireType !== 0) break;
             message.cause = reader.int32();
-            break;
+            continue;
           }
           case 7: {
+            if (wireType !== 0) break;
             message.effect = reader.int32();
-            break;
+            continue;
           }
           case 8: {
+            if (wireType !== 2) break;
             message.url = $root.transit_realtime.TranslatedString.decode(
               reader,
-              reader.uint32()
+              reader.uint32(),
+              undefined,
+              _depth + 1,
+              message.url
             );
-            break;
+            continue;
           }
           case 10: {
+            if (wireType !== 2) break;
             message.headerText = $root.transit_realtime.TranslatedString.decode(
               reader,
-              reader.uint32()
+              reader.uint32(),
+              undefined,
+              _depth + 1,
+              message.headerText
             );
-            break;
+            continue;
           }
           case 11: {
+            if (wireType !== 2) break;
             message.descriptionText =
               $root.transit_realtime.TranslatedString.decode(
                 reader,
-                reader.uint32()
+                reader.uint32(),
+                undefined,
+                _depth + 1,
+                message.descriptionText
               );
-            break;
+            continue;
           }
-          default:
-            reader.skipType(tag & 7);
-            break;
+        }
+        reader.skipType(wireType, _depth, tag);
+        if (!reader.discardUnknown) {
+          $util.makeProp(message, "$unknowns", false);
+          (message.$unknowns || (message.$unknowns = [])).push(
+            reader.raw(start, reader.pos)
+          );
         }
       }
+      if (_end !== undefined) throw Error("missing end group");
       return message;
     };
 
@@ -3103,7 +3727,7 @@ export const transit_realtime = ($root.transit_realtime = (() => {
      * @memberof transit_realtime.Alert
      * @static
      * @param {$protobuf.Reader|Uint8Array} reader Reader or buffer to decode from
-     * @returns {transit_realtime.Alert} Alert
+     * @returns {transit_realtime.Alert & transit_realtime.Alert.$Shape} Alert
      * @throws {Error} If the payload is not a reader or valid buffer
      * @throws {$protobuf.util.ProtocolError} If required fields are missing
      */
@@ -3120,9 +3744,11 @@ export const transit_realtime = ($root.transit_realtime = (() => {
      * @param {Object.<string,*>} message Plain object to verify
      * @returns {string|null} `null` if valid, otherwise the reason why it is not
      */
-    Alert.verify = function verify(message) {
+    Alert.verify = function verify(message, _depth) {
       if (typeof message !== "object" || message === null)
         return "object expected";
+      if (_depth === undefined) _depth = 0;
+      if (_depth > $util.recursionLimit) return "max depth exceeded";
       if (
         message.activePeriod != null &&
         message.hasOwnProperty("activePeriod")
@@ -3131,7 +3757,8 @@ export const transit_realtime = ($root.transit_realtime = (() => {
           return "activePeriod: array expected";
         for (let i = 0; i < message.activePeriod.length; ++i) {
           let error = $root.transit_realtime.TimeRange.verify(
-            message.activePeriod[i]
+            message.activePeriod[i],
+            _depth + 1
           );
           if (error) return "activePeriod." + error;
         }
@@ -3144,7 +3771,8 @@ export const transit_realtime = ($root.transit_realtime = (() => {
           return "informedEntity: array expected";
         for (let i = 0; i < message.informedEntity.length; ++i) {
           let error = $root.transit_realtime.EntitySelector.verify(
-            message.informedEntity[i]
+            message.informedEntity[i],
+            _depth + 1
           );
           if (error) return "informedEntity." + error;
         }
@@ -3183,12 +3811,16 @@ export const transit_realtime = ($root.transit_realtime = (() => {
             break;
         }
       if (message.url != null && message.hasOwnProperty("url")) {
-        let error = $root.transit_realtime.TranslatedString.verify(message.url);
+        let error = $root.transit_realtime.TranslatedString.verify(
+          message.url,
+          _depth + 1
+        );
         if (error) return "url." + error;
       }
       if (message.headerText != null && message.hasOwnProperty("headerText")) {
         let error = $root.transit_realtime.TranslatedString.verify(
-          message.headerText
+          message.headerText,
+          _depth + 1
         );
         if (error) return "headerText." + error;
       }
@@ -3197,7 +3829,8 @@ export const transit_realtime = ($root.transit_realtime = (() => {
         message.hasOwnProperty("descriptionText")
       ) {
         let error = $root.transit_realtime.TranslatedString.verify(
-          message.descriptionText
+          message.descriptionText,
+          _depth + 1
         );
         if (error) return "descriptionText." + error;
       }
@@ -3212,22 +3845,27 @@ export const transit_realtime = ($root.transit_realtime = (() => {
      * @param {Object.<string,*>} object Plain object
      * @returns {transit_realtime.Alert} Alert
      */
-    Alert.fromObject = function fromObject(object) {
+    Alert.fromObject = function fromObject(object, _depth) {
       if (object instanceof $root.transit_realtime.Alert) return object;
+      if (!$util.isObject(object))
+        throw TypeError(".transit_realtime.Alert: object expected");
+      if (_depth === undefined) _depth = 0;
+      if (_depth > $util.recursionLimit) throw Error("max depth exceeded");
       let message = new $root.transit_realtime.Alert();
       if (object.activePeriod) {
         if (!Array.isArray(object.activePeriod))
           throw TypeError(
             ".transit_realtime.Alert.activePeriod: array expected"
           );
-        message.activePeriod = [];
+        message.activePeriod = Array(object.activePeriod.length);
         for (let i = 0; i < object.activePeriod.length; ++i) {
-          if (typeof object.activePeriod[i] !== "object")
+          if (!$util.isObject(object.activePeriod[i]))
             throw TypeError(
               ".transit_realtime.Alert.activePeriod: object expected"
             );
           message.activePeriod[i] = $root.transit_realtime.TimeRange.fromObject(
-            object.activePeriod[i]
+            object.activePeriod[i],
+            _depth + 1
           );
         }
       }
@@ -3236,15 +3874,16 @@ export const transit_realtime = ($root.transit_realtime = (() => {
           throw TypeError(
             ".transit_realtime.Alert.informedEntity: array expected"
           );
-        message.informedEntity = [];
+        message.informedEntity = Array(object.informedEntity.length);
         for (let i = 0; i < object.informedEntity.length; ++i) {
-          if (typeof object.informedEntity[i] !== "object")
+          if (!$util.isObject(object.informedEntity[i]))
             throw TypeError(
               ".transit_realtime.Alert.informedEntity: object expected"
             );
           message.informedEntity[i] =
             $root.transit_realtime.EntitySelector.fromObject(
-              object.informedEntity[i]
+              object.informedEntity[i],
+              _depth + 1
             );
         }
       }
@@ -3349,29 +3988,32 @@ export const transit_realtime = ($root.transit_realtime = (() => {
           break;
       }
       if (object.url != null) {
-        if (typeof object.url !== "object")
+        if (!$util.isObject(object.url))
           throw TypeError(".transit_realtime.Alert.url: object expected");
         message.url = $root.transit_realtime.TranslatedString.fromObject(
-          object.url
+          object.url,
+          _depth + 1
         );
       }
       if (object.headerText != null) {
-        if (typeof object.headerText !== "object")
+        if (!$util.isObject(object.headerText))
           throw TypeError(
             ".transit_realtime.Alert.headerText: object expected"
           );
         message.headerText = $root.transit_realtime.TranslatedString.fromObject(
-          object.headerText
+          object.headerText,
+          _depth + 1
         );
       }
       if (object.descriptionText != null) {
-        if (typeof object.descriptionText !== "object")
+        if (!$util.isObject(object.descriptionText))
           throw TypeError(
             ".transit_realtime.Alert.descriptionText: object expected"
           );
         message.descriptionText =
           $root.transit_realtime.TranslatedString.fromObject(
-            object.descriptionText
+            object.descriptionText,
+            _depth + 1
           );
       }
       return message;
@@ -3386,8 +4028,10 @@ export const transit_realtime = ($root.transit_realtime = (() => {
      * @param {$protobuf.IConversionOptions} [options] Conversion options
      * @returns {Object.<string,*>} Plain object
      */
-    Alert.toObject = function toObject(message, options) {
+    Alert.toObject = function toObject(message, options, _depth) {
       if (!options) options = {};
+      if (_depth === undefined) _depth = 0;
+      if (_depth > $util.recursionLimit) throw Error("max depth exceeded");
       let object = {};
       if (options.arrays || options.defaults) {
         object.activePeriod = [];
@@ -3401,20 +4045,22 @@ export const transit_realtime = ($root.transit_realtime = (() => {
         object.descriptionText = null;
       }
       if (message.activePeriod && message.activePeriod.length) {
-        object.activePeriod = [];
+        object.activePeriod = Array(message.activePeriod.length);
         for (let j = 0; j < message.activePeriod.length; ++j)
           object.activePeriod[j] = $root.transit_realtime.TimeRange.toObject(
             message.activePeriod[j],
-            options
+            options,
+            _depth + 1
           );
       }
       if (message.informedEntity && message.informedEntity.length) {
-        object.informedEntity = [];
+        object.informedEntity = Array(message.informedEntity.length);
         for (let j = 0; j < message.informedEntity.length; ++j)
           object.informedEntity[j] =
             $root.transit_realtime.EntitySelector.toObject(
               message.informedEntity[j],
-              options
+              options,
+              _depth + 1
             );
       }
       if (message.cause != null && message.hasOwnProperty("cause"))
@@ -3434,12 +4080,14 @@ export const transit_realtime = ($root.transit_realtime = (() => {
       if (message.url != null && message.hasOwnProperty("url"))
         object.url = $root.transit_realtime.TranslatedString.toObject(
           message.url,
-          options
+          options,
+          _depth + 1
         );
       if (message.headerText != null && message.hasOwnProperty("headerText"))
         object.headerText = $root.transit_realtime.TranslatedString.toObject(
           message.headerText,
-          options
+          options,
+          _depth + 1
         );
       if (
         message.descriptionText != null &&
@@ -3448,7 +4096,8 @@ export const transit_realtime = ($root.transit_realtime = (() => {
         object.descriptionText =
           $root.transit_realtime.TranslatedString.toObject(
             message.descriptionText,
-            options
+            options,
+            _depth + 1
           );
       return object;
     };
@@ -3465,18 +4114,16 @@ export const transit_realtime = ($root.transit_realtime = (() => {
     };
 
     /**
-     * Gets the default type url for Alert
+     * Gets the type url for Alert
      * @function getTypeUrl
      * @memberof transit_realtime.Alert
      * @static
-     * @param {string} [typeUrlPrefix] your custom typeUrlPrefix(default "type.googleapis.com")
-     * @returns {string} The default type url
+     * @param {string} [prefix] Custom type url prefix, defaults to `"type.googleapis.com"`
+     * @returns {string} The type url
      */
-    Alert.getTypeUrl = function getTypeUrl(typeUrlPrefix) {
-      if (typeUrlPrefix === undefined) {
-        typeUrlPrefix = "type.googleapis.com";
-      }
-      return typeUrlPrefix + "/transit_realtime.Alert";
+    Alert.getTypeUrl = function getTypeUrl(prefix) {
+      if (prefix === undefined) prefix = "type.googleapis.com";
+      return prefix + "/transit_realtime.Alert";
     };
 
     /**
@@ -3549,24 +4196,38 @@ export const transit_realtime = ($root.transit_realtime = (() => {
   transit_realtime.TimeRange = (function () {
     /**
      * Properties of a TimeRange.
-     * @memberof transit_realtime
-     * @interface ITimeRange
+     * @typedef {Object} transit_realtime.TimeRange.$Properties
      * @property {number|Long|null} [start] TimeRange start
      * @property {number|Long|null} [end] TimeRange end
+     * @property {Array.<Uint8Array>} [$unknowns] Unknown fields preserved while decoding
+     */
+
+    /**
+     * Properties of a TimeRange.
+     * @memberof transit_realtime
+     * @interface ITimeRange
+     * @augments transit_realtime.TimeRange.$Properties
+     * @deprecated Use transit_realtime.TimeRange.$Properties instead.
+     */
+
+    /**
+     * Shape of a TimeRange.
+     * @typedef {transit_realtime.TimeRange.$Properties} transit_realtime.TimeRange.$Shape
      */
 
     /**
      * Constructs a new TimeRange.
      * @memberof transit_realtime
      * @classdesc Represents a TimeRange.
-     * @implements ITimeRange
      * @constructor
-     * @param {transit_realtime.ITimeRange=} [properties] Properties to set
+     * @param {transit_realtime.TimeRange.$Properties=} [properties] Properties to set
+     * @property {Array.<Uint8Array>} [$unknowns] Unknown fields preserved while decoding
      */
     function TimeRange(properties) {
       if (properties)
         for (let keys = Object.keys(properties), i = 0; i < keys.length; ++i)
-          if (properties[keys[i]] != null) this[keys[i]] = properties[keys[i]];
+          if (properties[keys[i]] != null && keys[i] !== "__proto__")
+            this[keys[i]] = properties[keys[i]];
     }
 
     /**
@@ -3592,8 +4253,12 @@ export const transit_realtime = ($root.transit_realtime = (() => {
      * @function create
      * @memberof transit_realtime.TimeRange
      * @static
-     * @param {transit_realtime.ITimeRange=} [properties] Properties to set
+     * @param {transit_realtime.TimeRange.$Properties=} [properties] Properties to set
      * @returns {transit_realtime.TimeRange} TimeRange instance
+     * @type {{
+     *   (properties: transit_realtime.TimeRange.$Shape): transit_realtime.TimeRange & transit_realtime.TimeRange.$Shape;
+     *   (properties?: transit_realtime.TimeRange.$Properties): transit_realtime.TimeRange;
+     * }}
      */
     TimeRange.create = function create(properties) {
       return new TimeRange(properties);
@@ -3604,16 +4269,24 @@ export const transit_realtime = ($root.transit_realtime = (() => {
      * @function encode
      * @memberof transit_realtime.TimeRange
      * @static
-     * @param {transit_realtime.ITimeRange} message TimeRange message or plain object to encode
+     * @param {transit_realtime.TimeRange.$Properties} message TimeRange message or plain object to encode
      * @param {$protobuf.Writer} [writer] Writer to encode to
      * @returns {$protobuf.Writer} Writer
      */
-    TimeRange.encode = function encode(message, writer) {
+    TimeRange.encode = function encode(message, writer, _depth) {
       if (!writer) writer = $Writer.create();
+      if (_depth === undefined) _depth = 0;
+      if (_depth > $util.recursionLimit) throw Error("max depth exceeded");
       if (message.start != null && Object.hasOwnProperty.call(message, "start"))
         writer.uint32(/* id 1, wireType 0 =*/ 8).uint64(message.start);
       if (message.end != null && Object.hasOwnProperty.call(message, "end"))
         writer.uint32(/* id 2, wireType 0 =*/ 16).uint64(message.end);
+      if (
+        message.$unknowns != null &&
+        Object.hasOwnProperty.call(message, "$unknowns")
+      )
+        for (let i = 0; i < message.$unknowns.length; ++i)
+          writer.raw(message.$unknowns[i]);
       return writer;
     };
 
@@ -3622,12 +4295,15 @@ export const transit_realtime = ($root.transit_realtime = (() => {
      * @function encodeDelimited
      * @memberof transit_realtime.TimeRange
      * @static
-     * @param {transit_realtime.ITimeRange} message TimeRange message or plain object to encode
+     * @param {transit_realtime.TimeRange.$Properties} message TimeRange message or plain object to encode
      * @param {$protobuf.Writer} [writer] Writer to encode to
      * @returns {$protobuf.Writer} Writer
      */
     TimeRange.encodeDelimited = function encodeDelimited(message, writer) {
-      return this.encode(message, writer).ldelim();
+      return this.encode(
+        message,
+        writer && writer.len ? writer.fork() : writer
+      ).ldelim();
     };
 
     /**
@@ -3637,31 +4313,45 @@ export const transit_realtime = ($root.transit_realtime = (() => {
      * @static
      * @param {$protobuf.Reader|Uint8Array} reader Reader or buffer to decode from
      * @param {number} [length] Message length if known beforehand
-     * @returns {transit_realtime.TimeRange} TimeRange
+     * @returns {transit_realtime.TimeRange & transit_realtime.TimeRange.$Shape} TimeRange
      * @throws {Error} If the payload is not a reader or valid buffer
      * @throws {$protobuf.util.ProtocolError} If required fields are missing
      */
-    TimeRange.decode = function decode(reader, length, error) {
+    TimeRange.decode = function decode(reader, length, _end, _depth, _target) {
       if (!(reader instanceof $Reader)) reader = $Reader.create(reader);
+      if (_depth === undefined) _depth = 0;
+      if (_depth > $Reader.recursionLimit) throw Error("max depth exceeded");
       let end = length === undefined ? reader.len : reader.pos + length,
-        message = new $root.transit_realtime.TimeRange();
+        message = _target || new $root.transit_realtime.TimeRange();
       while (reader.pos < end) {
-        let tag = reader.uint32();
-        if (tag === error) break;
-        switch (tag >>> 3) {
+        let start = reader.pos;
+        let tag = reader.tag();
+        if (tag === _end) {
+          _end = undefined;
+          break;
+        }
+        let wireType = tag & 7;
+        switch ((tag >>>= 3)) {
           case 1: {
+            if (wireType !== 0) break;
             message.start = reader.uint64();
-            break;
+            continue;
           }
           case 2: {
+            if (wireType !== 0) break;
             message.end = reader.uint64();
-            break;
+            continue;
           }
-          default:
-            reader.skipType(tag & 7);
-            break;
+        }
+        reader.skipType(wireType, _depth, tag);
+        if (!reader.discardUnknown) {
+          $util.makeProp(message, "$unknowns", false);
+          (message.$unknowns || (message.$unknowns = [])).push(
+            reader.raw(start, reader.pos)
+          );
         }
       }
+      if (_end !== undefined) throw Error("missing end group");
       return message;
     };
 
@@ -3671,7 +4361,7 @@ export const transit_realtime = ($root.transit_realtime = (() => {
      * @memberof transit_realtime.TimeRange
      * @static
      * @param {$protobuf.Reader|Uint8Array} reader Reader or buffer to decode from
-     * @returns {transit_realtime.TimeRange} TimeRange
+     * @returns {transit_realtime.TimeRange & transit_realtime.TimeRange.$Shape} TimeRange
      * @throws {Error} If the payload is not a reader or valid buffer
      * @throws {$protobuf.util.ProtocolError} If required fields are missing
      */
@@ -3688,9 +4378,11 @@ export const transit_realtime = ($root.transit_realtime = (() => {
      * @param {Object.<string,*>} message Plain object to verify
      * @returns {string|null} `null` if valid, otherwise the reason why it is not
      */
-    TimeRange.verify = function verify(message) {
+    TimeRange.verify = function verify(message, _depth) {
       if (typeof message !== "object" || message === null)
         return "object expected";
+      if (_depth === undefined) _depth = 0;
+      if (_depth > $util.recursionLimit) return "max depth exceeded";
       if (message.start != null && message.hasOwnProperty("start"))
         if (
           !$util.isInteger(message.start) &&
@@ -3722,12 +4414,16 @@ export const transit_realtime = ($root.transit_realtime = (() => {
      * @param {Object.<string,*>} object Plain object
      * @returns {transit_realtime.TimeRange} TimeRange
      */
-    TimeRange.fromObject = function fromObject(object) {
+    TimeRange.fromObject = function fromObject(object, _depth) {
       if (object instanceof $root.transit_realtime.TimeRange) return object;
+      if (!$util.isObject(object))
+        throw TypeError(".transit_realtime.TimeRange: object expected");
+      if (_depth === undefined) _depth = 0;
+      if (_depth > $util.recursionLimit) throw Error("max depth exceeded");
       let message = new $root.transit_realtime.TimeRange();
       if (object.start != null)
         if ($util.Long)
-          (message.start = $util.Long.fromValue(object.start)).unsigned = true;
+          message.start = $util.Long.fromValue(object.start, true);
         else if (typeof object.start === "string")
           message.start = parseInt(object.start, 10);
         else if (typeof object.start === "number") message.start = object.start;
@@ -3737,8 +4433,7 @@ export const transit_realtime = ($root.transit_realtime = (() => {
             object.start.high >>> 0
           ).toNumber(true);
       if (object.end != null)
-        if ($util.Long)
-          (message.end = $util.Long.fromValue(object.end)).unsigned = true;
+        if ($util.Long) message.end = $util.Long.fromValue(object.end, true);
         else if (typeof object.end === "string")
           message.end = parseInt(object.end, 10);
         else if (typeof object.end === "number") message.end = object.end;
@@ -3759,8 +4454,10 @@ export const transit_realtime = ($root.transit_realtime = (() => {
      * @param {$protobuf.IConversionOptions} [options] Conversion options
      * @returns {Object.<string,*>} Plain object
      */
-    TimeRange.toObject = function toObject(message, options) {
+    TimeRange.toObject = function toObject(message, options, _depth) {
       if (!options) options = {};
+      if (_depth === undefined) _depth = 0;
+      if (_depth > $util.recursionLimit) throw Error("max depth exceeded");
       let object = {};
       if (options.defaults) {
         if ($util.Long) {
@@ -3770,8 +4467,16 @@ export const transit_realtime = ($root.transit_realtime = (() => {
               ? long.toString()
               : options.longs === Number
               ? long.toNumber()
+              : typeof BigInt !== "undefined" && options.longs === BigInt
+              ? long.toBigInt()
               : long;
-        } else object.start = options.longs === String ? "0" : 0;
+        } else
+          object.start =
+            options.longs === String
+              ? "0"
+              : typeof BigInt !== "undefined" && options.longs === BigInt
+              ? BigInt("0")
+              : 0;
         if ($util.Long) {
           let long = new $util.Long(0, 0, true);
           object.end =
@@ -3779,11 +4484,28 @@ export const transit_realtime = ($root.transit_realtime = (() => {
               ? long.toString()
               : options.longs === Number
               ? long.toNumber()
+              : typeof BigInt !== "undefined" && options.longs === BigInt
+              ? long.toBigInt()
               : long;
-        } else object.end = options.longs === String ? "0" : 0;
+        } else
+          object.end =
+            options.longs === String
+              ? "0"
+              : typeof BigInt !== "undefined" && options.longs === BigInt
+              ? BigInt("0")
+              : 0;
       }
       if (message.start != null && message.hasOwnProperty("start"))
-        if (typeof message.start === "number")
+        if (typeof BigInt !== "undefined" && options.longs === BigInt)
+          object.start =
+            typeof message.start === "number"
+              ? BigInt(message.start)
+              : $util.Long.fromBits(
+                  message.start.low >>> 0,
+                  message.start.high >>> 0,
+                  true
+                ).toBigInt();
+        else if (typeof message.start === "number")
           object.start =
             options.longs === String ? String(message.start) : message.start;
         else
@@ -3797,7 +4519,16 @@ export const transit_realtime = ($root.transit_realtime = (() => {
                 ).toNumber(true)
               : message.start;
       if (message.end != null && message.hasOwnProperty("end"))
-        if (typeof message.end === "number")
+        if (typeof BigInt !== "undefined" && options.longs === BigInt)
+          object.end =
+            typeof message.end === "number"
+              ? BigInt(message.end)
+              : $util.Long.fromBits(
+                  message.end.low >>> 0,
+                  message.end.high >>> 0,
+                  true
+                ).toBigInt();
+        else if (typeof message.end === "number")
           object.end =
             options.longs === String ? String(message.end) : message.end;
         else
@@ -3825,18 +4556,16 @@ export const transit_realtime = ($root.transit_realtime = (() => {
     };
 
     /**
-     * Gets the default type url for TimeRange
+     * Gets the type url for TimeRange
      * @function getTypeUrl
      * @memberof transit_realtime.TimeRange
      * @static
-     * @param {string} [typeUrlPrefix] your custom typeUrlPrefix(default "type.googleapis.com")
-     * @returns {string} The default type url
+     * @param {string} [prefix] Custom type url prefix, defaults to `"type.googleapis.com"`
+     * @returns {string} The type url
      */
-    TimeRange.getTypeUrl = function getTypeUrl(typeUrlPrefix) {
-      if (typeUrlPrefix === undefined) {
-        typeUrlPrefix = "type.googleapis.com";
-      }
-      return typeUrlPrefix + "/transit_realtime.TimeRange";
+    TimeRange.getTypeUrl = function getTypeUrl(prefix) {
+      if (prefix === undefined) prefix = "type.googleapis.com";
+      return prefix + "/transit_realtime.TimeRange";
     };
 
     return TimeRange;
@@ -3845,27 +4574,41 @@ export const transit_realtime = ($root.transit_realtime = (() => {
   transit_realtime.Position = (function () {
     /**
      * Properties of a Position.
-     * @memberof transit_realtime
-     * @interface IPosition
+     * @typedef {Object} transit_realtime.Position.$Properties
      * @property {number} latitude Position latitude
      * @property {number} longitude Position longitude
      * @property {number|null} [bearing] Position bearing
      * @property {number|null} [odometer] Position odometer
      * @property {number|null} [speed] Position speed
+     * @property {Array.<Uint8Array>} [$unknowns] Unknown fields preserved while decoding
+     */
+
+    /**
+     * Properties of a Position.
+     * @memberof transit_realtime
+     * @interface IPosition
+     * @augments transit_realtime.Position.$Properties
+     * @deprecated Use transit_realtime.Position.$Properties instead.
+     */
+
+    /**
+     * Shape of a Position.
+     * @typedef {transit_realtime.Position.$Properties} transit_realtime.Position.$Shape
      */
 
     /**
      * Constructs a new Position.
      * @memberof transit_realtime
      * @classdesc Represents a Position.
-     * @implements IPosition
      * @constructor
-     * @param {transit_realtime.IPosition=} [properties] Properties to set
+     * @param {transit_realtime.Position.$Properties=} [properties] Properties to set
+     * @property {Array.<Uint8Array>} [$unknowns] Unknown fields preserved while decoding
      */
     function Position(properties) {
       if (properties)
         for (let keys = Object.keys(properties), i = 0; i < keys.length; ++i)
-          if (properties[keys[i]] != null) this[keys[i]] = properties[keys[i]];
+          if (properties[keys[i]] != null && keys[i] !== "__proto__")
+            this[keys[i]] = properties[keys[i]];
     }
 
     /**
@@ -3913,8 +4656,12 @@ export const transit_realtime = ($root.transit_realtime = (() => {
      * @function create
      * @memberof transit_realtime.Position
      * @static
-     * @param {transit_realtime.IPosition=} [properties] Properties to set
+     * @param {transit_realtime.Position.$Properties=} [properties] Properties to set
      * @returns {transit_realtime.Position} Position instance
+     * @type {{
+     *   (properties: transit_realtime.Position.$Shape): transit_realtime.Position & transit_realtime.Position.$Shape;
+     *   (properties?: transit_realtime.Position.$Properties): transit_realtime.Position;
+     * }}
      */
     Position.create = function create(properties) {
       return new Position(properties);
@@ -3925,12 +4672,14 @@ export const transit_realtime = ($root.transit_realtime = (() => {
      * @function encode
      * @memberof transit_realtime.Position
      * @static
-     * @param {transit_realtime.IPosition} message Position message or plain object to encode
+     * @param {transit_realtime.Position.$Properties} message Position message or plain object to encode
      * @param {$protobuf.Writer} [writer] Writer to encode to
      * @returns {$protobuf.Writer} Writer
      */
-    Position.encode = function encode(message, writer) {
+    Position.encode = function encode(message, writer, _depth) {
       if (!writer) writer = $Writer.create();
+      if (_depth === undefined) _depth = 0;
+      if (_depth > $util.recursionLimit) throw Error("max depth exceeded");
       writer.uint32(/* id 1, wireType 5 =*/ 13).float(message.latitude);
       writer.uint32(/* id 2, wireType 5 =*/ 21).float(message.longitude);
       if (
@@ -3945,6 +4694,12 @@ export const transit_realtime = ($root.transit_realtime = (() => {
         writer.uint32(/* id 4, wireType 1 =*/ 33).double(message.odometer);
       if (message.speed != null && Object.hasOwnProperty.call(message, "speed"))
         writer.uint32(/* id 5, wireType 5 =*/ 45).float(message.speed);
+      if (
+        message.$unknowns != null &&
+        Object.hasOwnProperty.call(message, "$unknowns")
+      )
+        for (let i = 0; i < message.$unknowns.length; ++i)
+          writer.raw(message.$unknowns[i]);
       return writer;
     };
 
@@ -3953,12 +4708,15 @@ export const transit_realtime = ($root.transit_realtime = (() => {
      * @function encodeDelimited
      * @memberof transit_realtime.Position
      * @static
-     * @param {transit_realtime.IPosition} message Position message or plain object to encode
+     * @param {transit_realtime.Position.$Properties} message Position message or plain object to encode
      * @param {$protobuf.Writer} [writer] Writer to encode to
      * @returns {$protobuf.Writer} Writer
      */
     Position.encodeDelimited = function encodeDelimited(message, writer) {
-      return this.encode(message, writer).ldelim();
+      return this.encode(
+        message,
+        writer && writer.len ? writer.fork() : writer
+      ).ldelim();
     };
 
     /**
@@ -3968,43 +4726,60 @@ export const transit_realtime = ($root.transit_realtime = (() => {
      * @static
      * @param {$protobuf.Reader|Uint8Array} reader Reader or buffer to decode from
      * @param {number} [length] Message length if known beforehand
-     * @returns {transit_realtime.Position} Position
+     * @returns {transit_realtime.Position & transit_realtime.Position.$Shape} Position
      * @throws {Error} If the payload is not a reader or valid buffer
      * @throws {$protobuf.util.ProtocolError} If required fields are missing
      */
-    Position.decode = function decode(reader, length, error) {
+    Position.decode = function decode(reader, length, _end, _depth, _target) {
       if (!(reader instanceof $Reader)) reader = $Reader.create(reader);
+      if (_depth === undefined) _depth = 0;
+      if (_depth > $Reader.recursionLimit) throw Error("max depth exceeded");
       let end = length === undefined ? reader.len : reader.pos + length,
-        message = new $root.transit_realtime.Position();
+        message = _target || new $root.transit_realtime.Position();
       while (reader.pos < end) {
-        let tag = reader.uint32();
-        if (tag === error) break;
-        switch (tag >>> 3) {
+        let start = reader.pos;
+        let tag = reader.tag();
+        if (tag === _end) {
+          _end = undefined;
+          break;
+        }
+        let wireType = tag & 7;
+        switch ((tag >>>= 3)) {
           case 1: {
+            if (wireType !== 5) break;
             message.latitude = reader.float();
-            break;
+            continue;
           }
           case 2: {
+            if (wireType !== 5) break;
             message.longitude = reader.float();
-            break;
+            continue;
           }
           case 3: {
+            if (wireType !== 5) break;
             message.bearing = reader.float();
-            break;
+            continue;
           }
           case 4: {
+            if (wireType !== 1) break;
             message.odometer = reader.double();
-            break;
+            continue;
           }
           case 5: {
+            if (wireType !== 5) break;
             message.speed = reader.float();
-            break;
+            continue;
           }
-          default:
-            reader.skipType(tag & 7);
-            break;
+        }
+        reader.skipType(wireType, _depth, tag);
+        if (!reader.discardUnknown) {
+          $util.makeProp(message, "$unknowns", false);
+          (message.$unknowns || (message.$unknowns = [])).push(
+            reader.raw(start, reader.pos)
+          );
         }
       }
+      if (_end !== undefined) throw Error("missing end group");
       if (!message.hasOwnProperty("latitude"))
         throw $util.ProtocolError("missing required 'latitude'", {
           instance: message,
@@ -4022,7 +4797,7 @@ export const transit_realtime = ($root.transit_realtime = (() => {
      * @memberof transit_realtime.Position
      * @static
      * @param {$protobuf.Reader|Uint8Array} reader Reader or buffer to decode from
-     * @returns {transit_realtime.Position} Position
+     * @returns {transit_realtime.Position & transit_realtime.Position.$Shape} Position
      * @throws {Error} If the payload is not a reader or valid buffer
      * @throws {$protobuf.util.ProtocolError} If required fields are missing
      */
@@ -4039,9 +4814,11 @@ export const transit_realtime = ($root.transit_realtime = (() => {
      * @param {Object.<string,*>} message Plain object to verify
      * @returns {string|null} `null` if valid, otherwise the reason why it is not
      */
-    Position.verify = function verify(message) {
+    Position.verify = function verify(message, _depth) {
       if (typeof message !== "object" || message === null)
         return "object expected";
+      if (_depth === undefined) _depth = 0;
+      if (_depth > $util.recursionLimit) return "max depth exceeded";
       if (typeof message.latitude !== "number")
         return "latitude: number expected";
       if (typeof message.longitude !== "number")
@@ -4065,8 +4842,12 @@ export const transit_realtime = ($root.transit_realtime = (() => {
      * @param {Object.<string,*>} object Plain object
      * @returns {transit_realtime.Position} Position
      */
-    Position.fromObject = function fromObject(object) {
+    Position.fromObject = function fromObject(object, _depth) {
       if (object instanceof $root.transit_realtime.Position) return object;
+      if (!$util.isObject(object))
+        throw TypeError(".transit_realtime.Position: object expected");
+      if (_depth === undefined) _depth = 0;
+      if (_depth > $util.recursionLimit) throw Error("max depth exceeded");
       let message = new $root.transit_realtime.Position();
       if (object.latitude != null) message.latitude = Number(object.latitude);
       if (object.longitude != null)
@@ -4086,8 +4867,10 @@ export const transit_realtime = ($root.transit_realtime = (() => {
      * @param {$protobuf.IConversionOptions} [options] Conversion options
      * @returns {Object.<string,*>} Plain object
      */
-    Position.toObject = function toObject(message, options) {
+    Position.toObject = function toObject(message, options, _depth) {
       if (!options) options = {};
+      if (_depth === undefined) _depth = 0;
+      if (_depth > $util.recursionLimit) throw Error("max depth exceeded");
       let object = {};
       if (options.defaults) {
         object.latitude = 0;
@@ -4136,18 +4919,16 @@ export const transit_realtime = ($root.transit_realtime = (() => {
     };
 
     /**
-     * Gets the default type url for Position
+     * Gets the type url for Position
      * @function getTypeUrl
      * @memberof transit_realtime.Position
      * @static
-     * @param {string} [typeUrlPrefix] your custom typeUrlPrefix(default "type.googleapis.com")
-     * @returns {string} The default type url
+     * @param {string} [prefix] Custom type url prefix, defaults to `"type.googleapis.com"`
+     * @returns {string} The type url
      */
-    Position.getTypeUrl = function getTypeUrl(typeUrlPrefix) {
-      if (typeUrlPrefix === undefined) {
-        typeUrlPrefix = "type.googleapis.com";
-      }
-      return typeUrlPrefix + "/transit_realtime.Position";
+    Position.getTypeUrl = function getTypeUrl(prefix) {
+      if (prefix === undefined) prefix = "type.googleapis.com";
+      return prefix + "/transit_realtime.Position";
     };
 
     return Position;
@@ -4156,28 +4937,42 @@ export const transit_realtime = ($root.transit_realtime = (() => {
   transit_realtime.TripDescriptor = (function () {
     /**
      * Properties of a TripDescriptor.
-     * @memberof transit_realtime
-     * @interface ITripDescriptor
+     * @typedef {Object} transit_realtime.TripDescriptor.$Properties
      * @property {string|null} [tripId] TripDescriptor tripId
      * @property {string|null} [routeId] TripDescriptor routeId
      * @property {number|null} [directionId] TripDescriptor directionId
      * @property {string|null} [startTime] TripDescriptor startTime
      * @property {string|null} [startDate] TripDescriptor startDate
      * @property {transit_realtime.TripDescriptor.ScheduleRelationship|null} [scheduleRelationship] TripDescriptor scheduleRelationship
+     * @property {Array.<Uint8Array>} [$unknowns] Unknown fields preserved while decoding
+     */
+
+    /**
+     * Properties of a TripDescriptor.
+     * @memberof transit_realtime
+     * @interface ITripDescriptor
+     * @augments transit_realtime.TripDescriptor.$Properties
+     * @deprecated Use transit_realtime.TripDescriptor.$Properties instead.
+     */
+
+    /**
+     * Shape of a TripDescriptor.
+     * @typedef {transit_realtime.TripDescriptor.$Properties} transit_realtime.TripDescriptor.$Shape
      */
 
     /**
      * Constructs a new TripDescriptor.
      * @memberof transit_realtime
      * @classdesc Represents a TripDescriptor.
-     * @implements ITripDescriptor
      * @constructor
-     * @param {transit_realtime.ITripDescriptor=} [properties] Properties to set
+     * @param {transit_realtime.TripDescriptor.$Properties=} [properties] Properties to set
+     * @property {Array.<Uint8Array>} [$unknowns] Unknown fields preserved while decoding
      */
     function TripDescriptor(properties) {
       if (properties)
         for (let keys = Object.keys(properties), i = 0; i < keys.length; ++i)
-          if (properties[keys[i]] != null) this[keys[i]] = properties[keys[i]];
+          if (properties[keys[i]] != null && keys[i] !== "__proto__")
+            this[keys[i]] = properties[keys[i]];
     }
 
     /**
@@ -4233,8 +5028,12 @@ export const transit_realtime = ($root.transit_realtime = (() => {
      * @function create
      * @memberof transit_realtime.TripDescriptor
      * @static
-     * @param {transit_realtime.ITripDescriptor=} [properties] Properties to set
+     * @param {transit_realtime.TripDescriptor.$Properties=} [properties] Properties to set
      * @returns {transit_realtime.TripDescriptor} TripDescriptor instance
+     * @type {{
+     *   (properties: transit_realtime.TripDescriptor.$Shape): transit_realtime.TripDescriptor & transit_realtime.TripDescriptor.$Shape;
+     *   (properties?: transit_realtime.TripDescriptor.$Properties): transit_realtime.TripDescriptor;
+     * }}
      */
     TripDescriptor.create = function create(properties) {
       return new TripDescriptor(properties);
@@ -4245,12 +5044,14 @@ export const transit_realtime = ($root.transit_realtime = (() => {
      * @function encode
      * @memberof transit_realtime.TripDescriptor
      * @static
-     * @param {transit_realtime.ITripDescriptor} message TripDescriptor message or plain object to encode
+     * @param {transit_realtime.TripDescriptor.$Properties} message TripDescriptor message or plain object to encode
      * @param {$protobuf.Writer} [writer] Writer to encode to
      * @returns {$protobuf.Writer} Writer
      */
-    TripDescriptor.encode = function encode(message, writer) {
+    TripDescriptor.encode = function encode(message, writer, _depth) {
       if (!writer) writer = $Writer.create();
+      if (_depth === undefined) _depth = 0;
+      if (_depth > $util.recursionLimit) throw Error("max depth exceeded");
       if (
         message.tripId != null &&
         Object.hasOwnProperty.call(message, "tripId")
@@ -4283,6 +5084,12 @@ export const transit_realtime = ($root.transit_realtime = (() => {
         Object.hasOwnProperty.call(message, "directionId")
       )
         writer.uint32(/* id 6, wireType 0 =*/ 48).uint32(message.directionId);
+      if (
+        message.$unknowns != null &&
+        Object.hasOwnProperty.call(message, "$unknowns")
+      )
+        for (let i = 0; i < message.$unknowns.length; ++i)
+          writer.raw(message.$unknowns[i]);
       return writer;
     };
 
@@ -4291,12 +5098,15 @@ export const transit_realtime = ($root.transit_realtime = (() => {
      * @function encodeDelimited
      * @memberof transit_realtime.TripDescriptor
      * @static
-     * @param {transit_realtime.ITripDescriptor} message TripDescriptor message or plain object to encode
+     * @param {transit_realtime.TripDescriptor.$Properties} message TripDescriptor message or plain object to encode
      * @param {$protobuf.Writer} [writer] Writer to encode to
      * @returns {$protobuf.Writer} Writer
      */
     TripDescriptor.encodeDelimited = function encodeDelimited(message, writer) {
-      return this.encode(message, writer).ldelim();
+      return this.encode(
+        message,
+        writer && writer.len ? writer.fork() : writer
+      ).ldelim();
     };
 
     /**
@@ -4306,47 +5116,71 @@ export const transit_realtime = ($root.transit_realtime = (() => {
      * @static
      * @param {$protobuf.Reader|Uint8Array} reader Reader or buffer to decode from
      * @param {number} [length] Message length if known beforehand
-     * @returns {transit_realtime.TripDescriptor} TripDescriptor
+     * @returns {transit_realtime.TripDescriptor & transit_realtime.TripDescriptor.$Shape} TripDescriptor
      * @throws {Error} If the payload is not a reader or valid buffer
      * @throws {$protobuf.util.ProtocolError} If required fields are missing
      */
-    TripDescriptor.decode = function decode(reader, length, error) {
+    TripDescriptor.decode = function decode(
+      reader,
+      length,
+      _end,
+      _depth,
+      _target
+    ) {
       if (!(reader instanceof $Reader)) reader = $Reader.create(reader);
+      if (_depth === undefined) _depth = 0;
+      if (_depth > $Reader.recursionLimit) throw Error("max depth exceeded");
       let end = length === undefined ? reader.len : reader.pos + length,
-        message = new $root.transit_realtime.TripDescriptor();
+        message = _target || new $root.transit_realtime.TripDescriptor();
       while (reader.pos < end) {
-        let tag = reader.uint32();
-        if (tag === error) break;
-        switch (tag >>> 3) {
+        let start = reader.pos;
+        let tag = reader.tag();
+        if (tag === _end) {
+          _end = undefined;
+          break;
+        }
+        let wireType = tag & 7;
+        switch ((tag >>>= 3)) {
           case 1: {
+            if (wireType !== 2) break;
             message.tripId = reader.string();
-            break;
+            continue;
           }
           case 5: {
+            if (wireType !== 2) break;
             message.routeId = reader.string();
-            break;
+            continue;
           }
           case 6: {
+            if (wireType !== 0) break;
             message.directionId = reader.uint32();
-            break;
+            continue;
           }
           case 2: {
+            if (wireType !== 2) break;
             message.startTime = reader.string();
-            break;
+            continue;
           }
           case 3: {
+            if (wireType !== 2) break;
             message.startDate = reader.string();
-            break;
+            continue;
           }
           case 4: {
+            if (wireType !== 0) break;
             message.scheduleRelationship = reader.int32();
-            break;
+            continue;
           }
-          default:
-            reader.skipType(tag & 7);
-            break;
+        }
+        reader.skipType(wireType, _depth, tag);
+        if (!reader.discardUnknown) {
+          $util.makeProp(message, "$unknowns", false);
+          (message.$unknowns || (message.$unknowns = [])).push(
+            reader.raw(start, reader.pos)
+          );
         }
       }
+      if (_end !== undefined) throw Error("missing end group");
       return message;
     };
 
@@ -4356,7 +5190,7 @@ export const transit_realtime = ($root.transit_realtime = (() => {
      * @memberof transit_realtime.TripDescriptor
      * @static
      * @param {$protobuf.Reader|Uint8Array} reader Reader or buffer to decode from
-     * @returns {transit_realtime.TripDescriptor} TripDescriptor
+     * @returns {transit_realtime.TripDescriptor & transit_realtime.TripDescriptor.$Shape} TripDescriptor
      * @throws {Error} If the payload is not a reader or valid buffer
      * @throws {$protobuf.util.ProtocolError} If required fields are missing
      */
@@ -4373,9 +5207,11 @@ export const transit_realtime = ($root.transit_realtime = (() => {
      * @param {Object.<string,*>} message Plain object to verify
      * @returns {string|null} `null` if valid, otherwise the reason why it is not
      */
-    TripDescriptor.verify = function verify(message) {
+    TripDescriptor.verify = function verify(message, _depth) {
       if (typeof message !== "object" || message === null)
         return "object expected";
+      if (_depth === undefined) _depth = 0;
+      if (_depth > $util.recursionLimit) return "max depth exceeded";
       if (message.tripId != null && message.hasOwnProperty("tripId"))
         if (!$util.isString(message.tripId)) return "tripId: string expected";
       if (message.routeId != null && message.hasOwnProperty("routeId"))
@@ -4413,9 +5249,13 @@ export const transit_realtime = ($root.transit_realtime = (() => {
      * @param {Object.<string,*>} object Plain object
      * @returns {transit_realtime.TripDescriptor} TripDescriptor
      */
-    TripDescriptor.fromObject = function fromObject(object) {
+    TripDescriptor.fromObject = function fromObject(object, _depth) {
       if (object instanceof $root.transit_realtime.TripDescriptor)
         return object;
+      if (!$util.isObject(object))
+        throw TypeError(".transit_realtime.TripDescriptor: object expected");
+      if (_depth === undefined) _depth = 0;
+      if (_depth > $util.recursionLimit) throw Error("max depth exceeded");
       let message = new $root.transit_realtime.TripDescriptor();
       if (object.tripId != null) message.tripId = String(object.tripId);
       if (object.routeId != null) message.routeId = String(object.routeId);
@@ -4461,8 +5301,10 @@ export const transit_realtime = ($root.transit_realtime = (() => {
      * @param {$protobuf.IConversionOptions} [options] Conversion options
      * @returns {Object.<string,*>} Plain object
      */
-    TripDescriptor.toObject = function toObject(message, options) {
+    TripDescriptor.toObject = function toObject(message, options, _depth) {
       if (!options) options = {};
+      if (_depth === undefined) _depth = 0;
+      if (_depth > $util.recursionLimit) throw Error("max depth exceeded");
       let object = {};
       if (options.defaults) {
         object.tripId = "";
@@ -4512,18 +5354,16 @@ export const transit_realtime = ($root.transit_realtime = (() => {
     };
 
     /**
-     * Gets the default type url for TripDescriptor
+     * Gets the type url for TripDescriptor
      * @function getTypeUrl
      * @memberof transit_realtime.TripDescriptor
      * @static
-     * @param {string} [typeUrlPrefix] your custom typeUrlPrefix(default "type.googleapis.com")
-     * @returns {string} The default type url
+     * @param {string} [prefix] Custom type url prefix, defaults to `"type.googleapis.com"`
+     * @returns {string} The type url
      */
-    TripDescriptor.getTypeUrl = function getTypeUrl(typeUrlPrefix) {
-      if (typeUrlPrefix === undefined) {
-        typeUrlPrefix = "type.googleapis.com";
-      }
-      return typeUrlPrefix + "/transit_realtime.TripDescriptor";
+    TripDescriptor.getTypeUrl = function getTypeUrl(prefix) {
+      if (prefix === undefined) prefix = "type.googleapis.com";
+      return prefix + "/transit_realtime.TripDescriptor";
     };
 
     /**
@@ -4551,25 +5391,39 @@ export const transit_realtime = ($root.transit_realtime = (() => {
   transit_realtime.VehicleDescriptor = (function () {
     /**
      * Properties of a VehicleDescriptor.
-     * @memberof transit_realtime
-     * @interface IVehicleDescriptor
+     * @typedef {Object} transit_realtime.VehicleDescriptor.$Properties
      * @property {string|null} [id] VehicleDescriptor id
      * @property {string|null} [label] VehicleDescriptor label
      * @property {string|null} [licensePlate] VehicleDescriptor licensePlate
+     * @property {Array.<Uint8Array>} [$unknowns] Unknown fields preserved while decoding
+     */
+
+    /**
+     * Properties of a VehicleDescriptor.
+     * @memberof transit_realtime
+     * @interface IVehicleDescriptor
+     * @augments transit_realtime.VehicleDescriptor.$Properties
+     * @deprecated Use transit_realtime.VehicleDescriptor.$Properties instead.
+     */
+
+    /**
+     * Shape of a VehicleDescriptor.
+     * @typedef {transit_realtime.VehicleDescriptor.$Properties} transit_realtime.VehicleDescriptor.$Shape
      */
 
     /**
      * Constructs a new VehicleDescriptor.
      * @memberof transit_realtime
      * @classdesc Represents a VehicleDescriptor.
-     * @implements IVehicleDescriptor
      * @constructor
-     * @param {transit_realtime.IVehicleDescriptor=} [properties] Properties to set
+     * @param {transit_realtime.VehicleDescriptor.$Properties=} [properties] Properties to set
+     * @property {Array.<Uint8Array>} [$unknowns] Unknown fields preserved while decoding
      */
     function VehicleDescriptor(properties) {
       if (properties)
         for (let keys = Object.keys(properties), i = 0; i < keys.length; ++i)
-          if (properties[keys[i]] != null) this[keys[i]] = properties[keys[i]];
+          if (properties[keys[i]] != null && keys[i] !== "__proto__")
+            this[keys[i]] = properties[keys[i]];
     }
 
     /**
@@ -4601,8 +5455,12 @@ export const transit_realtime = ($root.transit_realtime = (() => {
      * @function create
      * @memberof transit_realtime.VehicleDescriptor
      * @static
-     * @param {transit_realtime.IVehicleDescriptor=} [properties] Properties to set
+     * @param {transit_realtime.VehicleDescriptor.$Properties=} [properties] Properties to set
      * @returns {transit_realtime.VehicleDescriptor} VehicleDescriptor instance
+     * @type {{
+     *   (properties: transit_realtime.VehicleDescriptor.$Shape): transit_realtime.VehicleDescriptor & transit_realtime.VehicleDescriptor.$Shape;
+     *   (properties?: transit_realtime.VehicleDescriptor.$Properties): transit_realtime.VehicleDescriptor;
+     * }}
      */
     VehicleDescriptor.create = function create(properties) {
       return new VehicleDescriptor(properties);
@@ -4613,12 +5471,14 @@ export const transit_realtime = ($root.transit_realtime = (() => {
      * @function encode
      * @memberof transit_realtime.VehicleDescriptor
      * @static
-     * @param {transit_realtime.IVehicleDescriptor} message VehicleDescriptor message or plain object to encode
+     * @param {transit_realtime.VehicleDescriptor.$Properties} message VehicleDescriptor message or plain object to encode
      * @param {$protobuf.Writer} [writer] Writer to encode to
      * @returns {$protobuf.Writer} Writer
      */
-    VehicleDescriptor.encode = function encode(message, writer) {
+    VehicleDescriptor.encode = function encode(message, writer, _depth) {
       if (!writer) writer = $Writer.create();
+      if (_depth === undefined) _depth = 0;
+      if (_depth > $util.recursionLimit) throw Error("max depth exceeded");
       if (message.id != null && Object.hasOwnProperty.call(message, "id"))
         writer.uint32(/* id 1, wireType 2 =*/ 10).string(message.id);
       if (message.label != null && Object.hasOwnProperty.call(message, "label"))
@@ -4628,6 +5488,12 @@ export const transit_realtime = ($root.transit_realtime = (() => {
         Object.hasOwnProperty.call(message, "licensePlate")
       )
         writer.uint32(/* id 3, wireType 2 =*/ 26).string(message.licensePlate);
+      if (
+        message.$unknowns != null &&
+        Object.hasOwnProperty.call(message, "$unknowns")
+      )
+        for (let i = 0; i < message.$unknowns.length; ++i)
+          writer.raw(message.$unknowns[i]);
       return writer;
     };
 
@@ -4636,7 +5502,7 @@ export const transit_realtime = ($root.transit_realtime = (() => {
      * @function encodeDelimited
      * @memberof transit_realtime.VehicleDescriptor
      * @static
-     * @param {transit_realtime.IVehicleDescriptor} message VehicleDescriptor message or plain object to encode
+     * @param {transit_realtime.VehicleDescriptor.$Properties} message VehicleDescriptor message or plain object to encode
      * @param {$protobuf.Writer} [writer] Writer to encode to
      * @returns {$protobuf.Writer} Writer
      */
@@ -4644,7 +5510,10 @@ export const transit_realtime = ($root.transit_realtime = (() => {
       message,
       writer
     ) {
-      return this.encode(message, writer).ldelim();
+      return this.encode(
+        message,
+        writer && writer.len ? writer.fork() : writer
+      ).ldelim();
     };
 
     /**
@@ -4654,35 +5523,56 @@ export const transit_realtime = ($root.transit_realtime = (() => {
      * @static
      * @param {$protobuf.Reader|Uint8Array} reader Reader or buffer to decode from
      * @param {number} [length] Message length if known beforehand
-     * @returns {transit_realtime.VehicleDescriptor} VehicleDescriptor
+     * @returns {transit_realtime.VehicleDescriptor & transit_realtime.VehicleDescriptor.$Shape} VehicleDescriptor
      * @throws {Error} If the payload is not a reader or valid buffer
      * @throws {$protobuf.util.ProtocolError} If required fields are missing
      */
-    VehicleDescriptor.decode = function decode(reader, length, error) {
+    VehicleDescriptor.decode = function decode(
+      reader,
+      length,
+      _end,
+      _depth,
+      _target
+    ) {
       if (!(reader instanceof $Reader)) reader = $Reader.create(reader);
+      if (_depth === undefined) _depth = 0;
+      if (_depth > $Reader.recursionLimit) throw Error("max depth exceeded");
       let end = length === undefined ? reader.len : reader.pos + length,
-        message = new $root.transit_realtime.VehicleDescriptor();
+        message = _target || new $root.transit_realtime.VehicleDescriptor();
       while (reader.pos < end) {
-        let tag = reader.uint32();
-        if (tag === error) break;
-        switch (tag >>> 3) {
+        let start = reader.pos;
+        let tag = reader.tag();
+        if (tag === _end) {
+          _end = undefined;
+          break;
+        }
+        let wireType = tag & 7;
+        switch ((tag >>>= 3)) {
           case 1: {
+            if (wireType !== 2) break;
             message.id = reader.string();
-            break;
+            continue;
           }
           case 2: {
+            if (wireType !== 2) break;
             message.label = reader.string();
-            break;
+            continue;
           }
           case 3: {
+            if (wireType !== 2) break;
             message.licensePlate = reader.string();
-            break;
+            continue;
           }
-          default:
-            reader.skipType(tag & 7);
-            break;
+        }
+        reader.skipType(wireType, _depth, tag);
+        if (!reader.discardUnknown) {
+          $util.makeProp(message, "$unknowns", false);
+          (message.$unknowns || (message.$unknowns = [])).push(
+            reader.raw(start, reader.pos)
+          );
         }
       }
+      if (_end !== undefined) throw Error("missing end group");
       return message;
     };
 
@@ -4692,7 +5582,7 @@ export const transit_realtime = ($root.transit_realtime = (() => {
      * @memberof transit_realtime.VehicleDescriptor
      * @static
      * @param {$protobuf.Reader|Uint8Array} reader Reader or buffer to decode from
-     * @returns {transit_realtime.VehicleDescriptor} VehicleDescriptor
+     * @returns {transit_realtime.VehicleDescriptor & transit_realtime.VehicleDescriptor.$Shape} VehicleDescriptor
      * @throws {Error} If the payload is not a reader or valid buffer
      * @throws {$protobuf.util.ProtocolError} If required fields are missing
      */
@@ -4709,9 +5599,11 @@ export const transit_realtime = ($root.transit_realtime = (() => {
      * @param {Object.<string,*>} message Plain object to verify
      * @returns {string|null} `null` if valid, otherwise the reason why it is not
      */
-    VehicleDescriptor.verify = function verify(message) {
+    VehicleDescriptor.verify = function verify(message, _depth) {
       if (typeof message !== "object" || message === null)
         return "object expected";
+      if (_depth === undefined) _depth = 0;
+      if (_depth > $util.recursionLimit) return "max depth exceeded";
       if (message.id != null && message.hasOwnProperty("id"))
         if (!$util.isString(message.id)) return "id: string expected";
       if (message.label != null && message.hasOwnProperty("label"))
@@ -4733,9 +5625,13 @@ export const transit_realtime = ($root.transit_realtime = (() => {
      * @param {Object.<string,*>} object Plain object
      * @returns {transit_realtime.VehicleDescriptor} VehicleDescriptor
      */
-    VehicleDescriptor.fromObject = function fromObject(object) {
+    VehicleDescriptor.fromObject = function fromObject(object, _depth) {
       if (object instanceof $root.transit_realtime.VehicleDescriptor)
         return object;
+      if (!$util.isObject(object))
+        throw TypeError(".transit_realtime.VehicleDescriptor: object expected");
+      if (_depth === undefined) _depth = 0;
+      if (_depth > $util.recursionLimit) throw Error("max depth exceeded");
       let message = new $root.transit_realtime.VehicleDescriptor();
       if (object.id != null) message.id = String(object.id);
       if (object.label != null) message.label = String(object.label);
@@ -4753,8 +5649,10 @@ export const transit_realtime = ($root.transit_realtime = (() => {
      * @param {$protobuf.IConversionOptions} [options] Conversion options
      * @returns {Object.<string,*>} Plain object
      */
-    VehicleDescriptor.toObject = function toObject(message, options) {
+    VehicleDescriptor.toObject = function toObject(message, options, _depth) {
       if (!options) options = {};
+      if (_depth === undefined) _depth = 0;
+      if (_depth > $util.recursionLimit) throw Error("max depth exceeded");
       let object = {};
       if (options.defaults) {
         object.id = "";
@@ -4785,18 +5683,16 @@ export const transit_realtime = ($root.transit_realtime = (() => {
     };
 
     /**
-     * Gets the default type url for VehicleDescriptor
+     * Gets the type url for VehicleDescriptor
      * @function getTypeUrl
      * @memberof transit_realtime.VehicleDescriptor
      * @static
-     * @param {string} [typeUrlPrefix] your custom typeUrlPrefix(default "type.googleapis.com")
-     * @returns {string} The default type url
+     * @param {string} [prefix] Custom type url prefix, defaults to `"type.googleapis.com"`
+     * @returns {string} The type url
      */
-    VehicleDescriptor.getTypeUrl = function getTypeUrl(typeUrlPrefix) {
-      if (typeUrlPrefix === undefined) {
-        typeUrlPrefix = "type.googleapis.com";
-      }
-      return typeUrlPrefix + "/transit_realtime.VehicleDescriptor";
+    VehicleDescriptor.getTypeUrl = function getTypeUrl(prefix) {
+      if (prefix === undefined) prefix = "type.googleapis.com";
+      return prefix + "/transit_realtime.VehicleDescriptor";
     };
 
     return VehicleDescriptor;
@@ -4805,27 +5701,41 @@ export const transit_realtime = ($root.transit_realtime = (() => {
   transit_realtime.EntitySelector = (function () {
     /**
      * Properties of an EntitySelector.
-     * @memberof transit_realtime
-     * @interface IEntitySelector
+     * @typedef {Object} transit_realtime.EntitySelector.$Properties
      * @property {string|null} [agencyId] EntitySelector agencyId
      * @property {string|null} [routeId] EntitySelector routeId
      * @property {number|null} [routeType] EntitySelector routeType
-     * @property {transit_realtime.ITripDescriptor|null} [trip] EntitySelector trip
+     * @property {transit_realtime.TripDescriptor.$Properties|null} [trip] EntitySelector trip
      * @property {string|null} [stopId] EntitySelector stopId
+     * @property {Array.<Uint8Array>} [$unknowns] Unknown fields preserved while decoding
+     */
+
+    /**
+     * Properties of an EntitySelector.
+     * @memberof transit_realtime
+     * @interface IEntitySelector
+     * @augments transit_realtime.EntitySelector.$Properties
+     * @deprecated Use transit_realtime.EntitySelector.$Properties instead.
+     */
+
+    /**
+     * Shape of an EntitySelector.
+     * @typedef {transit_realtime.EntitySelector.$Properties} transit_realtime.EntitySelector.$Shape
      */
 
     /**
      * Constructs a new EntitySelector.
      * @memberof transit_realtime
      * @classdesc Represents an EntitySelector.
-     * @implements IEntitySelector
      * @constructor
-     * @param {transit_realtime.IEntitySelector=} [properties] Properties to set
+     * @param {transit_realtime.EntitySelector.$Properties=} [properties] Properties to set
+     * @property {Array.<Uint8Array>} [$unknowns] Unknown fields preserved while decoding
      */
     function EntitySelector(properties) {
       if (properties)
         for (let keys = Object.keys(properties), i = 0; i < keys.length; ++i)
-          if (properties[keys[i]] != null) this[keys[i]] = properties[keys[i]];
+          if (properties[keys[i]] != null && keys[i] !== "__proto__")
+            this[keys[i]] = properties[keys[i]];
     }
 
     /**
@@ -4854,7 +5764,7 @@ export const transit_realtime = ($root.transit_realtime = (() => {
 
     /**
      * EntitySelector trip.
-     * @member {transit_realtime.ITripDescriptor|null|undefined} trip
+     * @member {transit_realtime.TripDescriptor.$Properties|null|undefined} trip
      * @memberof transit_realtime.EntitySelector
      * @instance
      */
@@ -4873,8 +5783,12 @@ export const transit_realtime = ($root.transit_realtime = (() => {
      * @function create
      * @memberof transit_realtime.EntitySelector
      * @static
-     * @param {transit_realtime.IEntitySelector=} [properties] Properties to set
+     * @param {transit_realtime.EntitySelector.$Properties=} [properties] Properties to set
      * @returns {transit_realtime.EntitySelector} EntitySelector instance
+     * @type {{
+     *   (properties: transit_realtime.EntitySelector.$Shape): transit_realtime.EntitySelector & transit_realtime.EntitySelector.$Shape;
+     *   (properties?: transit_realtime.EntitySelector.$Properties): transit_realtime.EntitySelector;
+     * }}
      */
     EntitySelector.create = function create(properties) {
       return new EntitySelector(properties);
@@ -4885,12 +5799,14 @@ export const transit_realtime = ($root.transit_realtime = (() => {
      * @function encode
      * @memberof transit_realtime.EntitySelector
      * @static
-     * @param {transit_realtime.IEntitySelector} message EntitySelector message or plain object to encode
+     * @param {transit_realtime.EntitySelector.$Properties} message EntitySelector message or plain object to encode
      * @param {$protobuf.Writer} [writer] Writer to encode to
      * @returns {$protobuf.Writer} Writer
      */
-    EntitySelector.encode = function encode(message, writer) {
+    EntitySelector.encode = function encode(message, writer, _depth) {
       if (!writer) writer = $Writer.create();
+      if (_depth === undefined) _depth = 0;
+      if (_depth > $util.recursionLimit) throw Error("max depth exceeded");
       if (
         message.agencyId != null &&
         Object.hasOwnProperty.call(message, "agencyId")
@@ -4909,13 +5825,20 @@ export const transit_realtime = ($root.transit_realtime = (() => {
       if (message.trip != null && Object.hasOwnProperty.call(message, "trip"))
         $root.transit_realtime.TripDescriptor.encode(
           message.trip,
-          writer.uint32(/* id 4, wireType 2 =*/ 34).fork()
+          writer.uint32(/* id 4, wireType 2 =*/ 34).fork(),
+          _depth + 1
         ).ldelim();
       if (
         message.stopId != null &&
         Object.hasOwnProperty.call(message, "stopId")
       )
         writer.uint32(/* id 5, wireType 2 =*/ 42).string(message.stopId);
+      if (
+        message.$unknowns != null &&
+        Object.hasOwnProperty.call(message, "$unknowns")
+      )
+        for (let i = 0; i < message.$unknowns.length; ++i)
+          writer.raw(message.$unknowns[i]);
       return writer;
     };
 
@@ -4924,12 +5847,15 @@ export const transit_realtime = ($root.transit_realtime = (() => {
      * @function encodeDelimited
      * @memberof transit_realtime.EntitySelector
      * @static
-     * @param {transit_realtime.IEntitySelector} message EntitySelector message or plain object to encode
+     * @param {transit_realtime.EntitySelector.$Properties} message EntitySelector message or plain object to encode
      * @param {$protobuf.Writer} [writer] Writer to encode to
      * @returns {$protobuf.Writer} Writer
      */
     EntitySelector.encodeDelimited = function encodeDelimited(message, writer) {
-      return this.encode(message, writer).ldelim();
+      return this.encode(
+        message,
+        writer && writer.len ? writer.fork() : writer
+      ).ldelim();
     };
 
     /**
@@ -4939,46 +5865,72 @@ export const transit_realtime = ($root.transit_realtime = (() => {
      * @static
      * @param {$protobuf.Reader|Uint8Array} reader Reader or buffer to decode from
      * @param {number} [length] Message length if known beforehand
-     * @returns {transit_realtime.EntitySelector} EntitySelector
+     * @returns {transit_realtime.EntitySelector & transit_realtime.EntitySelector.$Shape} EntitySelector
      * @throws {Error} If the payload is not a reader or valid buffer
      * @throws {$protobuf.util.ProtocolError} If required fields are missing
      */
-    EntitySelector.decode = function decode(reader, length, error) {
+    EntitySelector.decode = function decode(
+      reader,
+      length,
+      _end,
+      _depth,
+      _target
+    ) {
       if (!(reader instanceof $Reader)) reader = $Reader.create(reader);
+      if (_depth === undefined) _depth = 0;
+      if (_depth > $Reader.recursionLimit) throw Error("max depth exceeded");
       let end = length === undefined ? reader.len : reader.pos + length,
-        message = new $root.transit_realtime.EntitySelector();
+        message = _target || new $root.transit_realtime.EntitySelector();
       while (reader.pos < end) {
-        let tag = reader.uint32();
-        if (tag === error) break;
-        switch (tag >>> 3) {
+        let start = reader.pos;
+        let tag = reader.tag();
+        if (tag === _end) {
+          _end = undefined;
+          break;
+        }
+        let wireType = tag & 7;
+        switch ((tag >>>= 3)) {
           case 1: {
+            if (wireType !== 2) break;
             message.agencyId = reader.string();
-            break;
+            continue;
           }
           case 2: {
+            if (wireType !== 2) break;
             message.routeId = reader.string();
-            break;
+            continue;
           }
           case 3: {
+            if (wireType !== 0) break;
             message.routeType = reader.int32();
-            break;
+            continue;
           }
           case 4: {
+            if (wireType !== 2) break;
             message.trip = $root.transit_realtime.TripDescriptor.decode(
               reader,
-              reader.uint32()
+              reader.uint32(),
+              undefined,
+              _depth + 1,
+              message.trip
             );
-            break;
+            continue;
           }
           case 5: {
+            if (wireType !== 2) break;
             message.stopId = reader.string();
-            break;
+            continue;
           }
-          default:
-            reader.skipType(tag & 7);
-            break;
+        }
+        reader.skipType(wireType, _depth, tag);
+        if (!reader.discardUnknown) {
+          $util.makeProp(message, "$unknowns", false);
+          (message.$unknowns || (message.$unknowns = [])).push(
+            reader.raw(start, reader.pos)
+          );
         }
       }
+      if (_end !== undefined) throw Error("missing end group");
       return message;
     };
 
@@ -4988,7 +5940,7 @@ export const transit_realtime = ($root.transit_realtime = (() => {
      * @memberof transit_realtime.EntitySelector
      * @static
      * @param {$protobuf.Reader|Uint8Array} reader Reader or buffer to decode from
-     * @returns {transit_realtime.EntitySelector} EntitySelector
+     * @returns {transit_realtime.EntitySelector & transit_realtime.EntitySelector.$Shape} EntitySelector
      * @throws {Error} If the payload is not a reader or valid buffer
      * @throws {$protobuf.util.ProtocolError} If required fields are missing
      */
@@ -5005,9 +5957,11 @@ export const transit_realtime = ($root.transit_realtime = (() => {
      * @param {Object.<string,*>} message Plain object to verify
      * @returns {string|null} `null` if valid, otherwise the reason why it is not
      */
-    EntitySelector.verify = function verify(message) {
+    EntitySelector.verify = function verify(message, _depth) {
       if (typeof message !== "object" || message === null)
         return "object expected";
+      if (_depth === undefined) _depth = 0;
+      if (_depth > $util.recursionLimit) return "max depth exceeded";
       if (message.agencyId != null && message.hasOwnProperty("agencyId"))
         if (!$util.isString(message.agencyId))
           return "agencyId: string expected";
@@ -5017,7 +5971,10 @@ export const transit_realtime = ($root.transit_realtime = (() => {
         if (!$util.isInteger(message.routeType))
           return "routeType: integer expected";
       if (message.trip != null && message.hasOwnProperty("trip")) {
-        let error = $root.transit_realtime.TripDescriptor.verify(message.trip);
+        let error = $root.transit_realtime.TripDescriptor.verify(
+          message.trip,
+          _depth + 1
+        );
         if (error) return "trip." + error;
       }
       if (message.stopId != null && message.hasOwnProperty("stopId"))
@@ -5033,20 +5990,25 @@ export const transit_realtime = ($root.transit_realtime = (() => {
      * @param {Object.<string,*>} object Plain object
      * @returns {transit_realtime.EntitySelector} EntitySelector
      */
-    EntitySelector.fromObject = function fromObject(object) {
+    EntitySelector.fromObject = function fromObject(object, _depth) {
       if (object instanceof $root.transit_realtime.EntitySelector)
         return object;
+      if (!$util.isObject(object))
+        throw TypeError(".transit_realtime.EntitySelector: object expected");
+      if (_depth === undefined) _depth = 0;
+      if (_depth > $util.recursionLimit) throw Error("max depth exceeded");
       let message = new $root.transit_realtime.EntitySelector();
       if (object.agencyId != null) message.agencyId = String(object.agencyId);
       if (object.routeId != null) message.routeId = String(object.routeId);
       if (object.routeType != null) message.routeType = object.routeType | 0;
       if (object.trip != null) {
-        if (typeof object.trip !== "object")
+        if (!$util.isObject(object.trip))
           throw TypeError(
             ".transit_realtime.EntitySelector.trip: object expected"
           );
         message.trip = $root.transit_realtime.TripDescriptor.fromObject(
-          object.trip
+          object.trip,
+          _depth + 1
         );
       }
       if (object.stopId != null) message.stopId = String(object.stopId);
@@ -5062,8 +6024,10 @@ export const transit_realtime = ($root.transit_realtime = (() => {
      * @param {$protobuf.IConversionOptions} [options] Conversion options
      * @returns {Object.<string,*>} Plain object
      */
-    EntitySelector.toObject = function toObject(message, options) {
+    EntitySelector.toObject = function toObject(message, options, _depth) {
       if (!options) options = {};
+      if (_depth === undefined) _depth = 0;
+      if (_depth > $util.recursionLimit) throw Error("max depth exceeded");
       let object = {};
       if (options.defaults) {
         object.agencyId = "";
@@ -5081,7 +6045,8 @@ export const transit_realtime = ($root.transit_realtime = (() => {
       if (message.trip != null && message.hasOwnProperty("trip"))
         object.trip = $root.transit_realtime.TripDescriptor.toObject(
           message.trip,
-          options
+          options,
+          _depth + 1
         );
       if (message.stopId != null && message.hasOwnProperty("stopId"))
         object.stopId = message.stopId;
@@ -5100,18 +6065,16 @@ export const transit_realtime = ($root.transit_realtime = (() => {
     };
 
     /**
-     * Gets the default type url for EntitySelector
+     * Gets the type url for EntitySelector
      * @function getTypeUrl
      * @memberof transit_realtime.EntitySelector
      * @static
-     * @param {string} [typeUrlPrefix] your custom typeUrlPrefix(default "type.googleapis.com")
-     * @returns {string} The default type url
+     * @param {string} [prefix] Custom type url prefix, defaults to `"type.googleapis.com"`
+     * @returns {string} The type url
      */
-    EntitySelector.getTypeUrl = function getTypeUrl(typeUrlPrefix) {
-      if (typeUrlPrefix === undefined) {
-        typeUrlPrefix = "type.googleapis.com";
-      }
-      return typeUrlPrefix + "/transit_realtime.EntitySelector";
+    EntitySelector.getTypeUrl = function getTypeUrl(prefix) {
+      if (prefix === undefined) prefix = "type.googleapis.com";
+      return prefix + "/transit_realtime.EntitySelector";
     };
 
     return EntitySelector;
@@ -5120,29 +6083,43 @@ export const transit_realtime = ($root.transit_realtime = (() => {
   transit_realtime.TranslatedString = (function () {
     /**
      * Properties of a TranslatedString.
+     * @typedef {Object} transit_realtime.TranslatedString.$Properties
+     * @property {Array.<transit_realtime.TranslatedString.Translation.$Properties>|null} [translation] TranslatedString translation
+     * @property {Array.<Uint8Array>} [$unknowns] Unknown fields preserved while decoding
+     */
+
+    /**
+     * Properties of a TranslatedString.
      * @memberof transit_realtime
      * @interface ITranslatedString
-     * @property {Array.<transit_realtime.TranslatedString.ITranslation>|null} [translation] TranslatedString translation
+     * @augments transit_realtime.TranslatedString.$Properties
+     * @deprecated Use transit_realtime.TranslatedString.$Properties instead.
+     */
+
+    /**
+     * Shape of a TranslatedString.
+     * @typedef {transit_realtime.TranslatedString.$Properties} transit_realtime.TranslatedString.$Shape
      */
 
     /**
      * Constructs a new TranslatedString.
      * @memberof transit_realtime
      * @classdesc Represents a TranslatedString.
-     * @implements ITranslatedString
      * @constructor
-     * @param {transit_realtime.ITranslatedString=} [properties] Properties to set
+     * @param {transit_realtime.TranslatedString.$Properties=} [properties] Properties to set
+     * @property {Array.<Uint8Array>} [$unknowns] Unknown fields preserved while decoding
      */
     function TranslatedString(properties) {
       this.translation = [];
       if (properties)
         for (let keys = Object.keys(properties), i = 0; i < keys.length; ++i)
-          if (properties[keys[i]] != null) this[keys[i]] = properties[keys[i]];
+          if (properties[keys[i]] != null && keys[i] !== "__proto__")
+            this[keys[i]] = properties[keys[i]];
     }
 
     /**
      * TranslatedString translation.
-     * @member {Array.<transit_realtime.TranslatedString.ITranslation>} translation
+     * @member {Array.<transit_realtime.TranslatedString.Translation.$Properties>} translation
      * @memberof transit_realtime.TranslatedString
      * @instance
      */
@@ -5153,8 +6130,12 @@ export const transit_realtime = ($root.transit_realtime = (() => {
      * @function create
      * @memberof transit_realtime.TranslatedString
      * @static
-     * @param {transit_realtime.ITranslatedString=} [properties] Properties to set
+     * @param {transit_realtime.TranslatedString.$Properties=} [properties] Properties to set
      * @returns {transit_realtime.TranslatedString} TranslatedString instance
+     * @type {{
+     *   (properties: transit_realtime.TranslatedString.$Shape): transit_realtime.TranslatedString & transit_realtime.TranslatedString.$Shape;
+     *   (properties?: transit_realtime.TranslatedString.$Properties): transit_realtime.TranslatedString;
+     * }}
      */
     TranslatedString.create = function create(properties) {
       return new TranslatedString(properties);
@@ -5165,18 +6146,27 @@ export const transit_realtime = ($root.transit_realtime = (() => {
      * @function encode
      * @memberof transit_realtime.TranslatedString
      * @static
-     * @param {transit_realtime.ITranslatedString} message TranslatedString message or plain object to encode
+     * @param {transit_realtime.TranslatedString.$Properties} message TranslatedString message or plain object to encode
      * @param {$protobuf.Writer} [writer] Writer to encode to
      * @returns {$protobuf.Writer} Writer
      */
-    TranslatedString.encode = function encode(message, writer) {
+    TranslatedString.encode = function encode(message, writer, _depth) {
       if (!writer) writer = $Writer.create();
+      if (_depth === undefined) _depth = 0;
+      if (_depth > $util.recursionLimit) throw Error("max depth exceeded");
       if (message.translation != null && message.translation.length)
         for (let i = 0; i < message.translation.length; ++i)
           $root.transit_realtime.TranslatedString.Translation.encode(
             message.translation[i],
-            writer.uint32(/* id 1, wireType 2 =*/ 10).fork()
+            writer.uint32(/* id 1, wireType 2 =*/ 10).fork(),
+            _depth + 1
           ).ldelim();
+      if (
+        message.$unknowns != null &&
+        Object.hasOwnProperty.call(message, "$unknowns")
+      )
+        for (let i = 0; i < message.$unknowns.length; ++i)
+          writer.raw(message.$unknowns[i]);
       return writer;
     };
 
@@ -5185,7 +6175,7 @@ export const transit_realtime = ($root.transit_realtime = (() => {
      * @function encodeDelimited
      * @memberof transit_realtime.TranslatedString
      * @static
-     * @param {transit_realtime.ITranslatedString} message TranslatedString message or plain object to encode
+     * @param {transit_realtime.TranslatedString.$Properties} message TranslatedString message or plain object to encode
      * @param {$protobuf.Writer} [writer] Writer to encode to
      * @returns {$protobuf.Writer} Writer
      */
@@ -5193,7 +6183,10 @@ export const transit_realtime = ($root.transit_realtime = (() => {
       message,
       writer
     ) {
-      return this.encode(message, writer).ldelim();
+      return this.encode(
+        message,
+        writer && writer.len ? writer.fork() : writer
+      ).ldelim();
     };
 
     /**
@@ -5203,34 +6196,55 @@ export const transit_realtime = ($root.transit_realtime = (() => {
      * @static
      * @param {$protobuf.Reader|Uint8Array} reader Reader or buffer to decode from
      * @param {number} [length] Message length if known beforehand
-     * @returns {transit_realtime.TranslatedString} TranslatedString
+     * @returns {transit_realtime.TranslatedString & transit_realtime.TranslatedString.$Shape} TranslatedString
      * @throws {Error} If the payload is not a reader or valid buffer
      * @throws {$protobuf.util.ProtocolError} If required fields are missing
      */
-    TranslatedString.decode = function decode(reader, length, error) {
+    TranslatedString.decode = function decode(
+      reader,
+      length,
+      _end,
+      _depth,
+      _target
+    ) {
       if (!(reader instanceof $Reader)) reader = $Reader.create(reader);
+      if (_depth === undefined) _depth = 0;
+      if (_depth > $Reader.recursionLimit) throw Error("max depth exceeded");
       let end = length === undefined ? reader.len : reader.pos + length,
-        message = new $root.transit_realtime.TranslatedString();
+        message = _target || new $root.transit_realtime.TranslatedString();
       while (reader.pos < end) {
-        let tag = reader.uint32();
-        if (tag === error) break;
-        switch (tag >>> 3) {
+        let start = reader.pos;
+        let tag = reader.tag();
+        if (tag === _end) {
+          _end = undefined;
+          break;
+        }
+        let wireType = tag & 7;
+        switch ((tag >>>= 3)) {
           case 1: {
+            if (wireType !== 2) break;
             if (!(message.translation && message.translation.length))
               message.translation = [];
             message.translation.push(
               $root.transit_realtime.TranslatedString.Translation.decode(
                 reader,
-                reader.uint32()
+                reader.uint32(),
+                undefined,
+                _depth + 1
               )
             );
-            break;
+            continue;
           }
-          default:
-            reader.skipType(tag & 7);
-            break;
+        }
+        reader.skipType(wireType, _depth, tag);
+        if (!reader.discardUnknown) {
+          $util.makeProp(message, "$unknowns", false);
+          (message.$unknowns || (message.$unknowns = [])).push(
+            reader.raw(start, reader.pos)
+          );
         }
       }
+      if (_end !== undefined) throw Error("missing end group");
       return message;
     };
 
@@ -5240,7 +6254,7 @@ export const transit_realtime = ($root.transit_realtime = (() => {
      * @memberof transit_realtime.TranslatedString
      * @static
      * @param {$protobuf.Reader|Uint8Array} reader Reader or buffer to decode from
-     * @returns {transit_realtime.TranslatedString} TranslatedString
+     * @returns {transit_realtime.TranslatedString & transit_realtime.TranslatedString.$Shape} TranslatedString
      * @throws {Error} If the payload is not a reader or valid buffer
      * @throws {$protobuf.util.ProtocolError} If required fields are missing
      */
@@ -5257,9 +6271,11 @@ export const transit_realtime = ($root.transit_realtime = (() => {
      * @param {Object.<string,*>} message Plain object to verify
      * @returns {string|null} `null` if valid, otherwise the reason why it is not
      */
-    TranslatedString.verify = function verify(message) {
+    TranslatedString.verify = function verify(message, _depth) {
       if (typeof message !== "object" || message === null)
         return "object expected";
+      if (_depth === undefined) _depth = 0;
+      if (_depth > $util.recursionLimit) return "max depth exceeded";
       if (
         message.translation != null &&
         message.hasOwnProperty("translation")
@@ -5269,7 +6285,8 @@ export const transit_realtime = ($root.transit_realtime = (() => {
         for (let i = 0; i < message.translation.length; ++i) {
           let error =
             $root.transit_realtime.TranslatedString.Translation.verify(
-              message.translation[i]
+              message.translation[i],
+              _depth + 1
             );
           if (error) return "translation." + error;
         }
@@ -5285,24 +6302,29 @@ export const transit_realtime = ($root.transit_realtime = (() => {
      * @param {Object.<string,*>} object Plain object
      * @returns {transit_realtime.TranslatedString} TranslatedString
      */
-    TranslatedString.fromObject = function fromObject(object) {
+    TranslatedString.fromObject = function fromObject(object, _depth) {
       if (object instanceof $root.transit_realtime.TranslatedString)
         return object;
+      if (!$util.isObject(object))
+        throw TypeError(".transit_realtime.TranslatedString: object expected");
+      if (_depth === undefined) _depth = 0;
+      if (_depth > $util.recursionLimit) throw Error("max depth exceeded");
       let message = new $root.transit_realtime.TranslatedString();
       if (object.translation) {
         if (!Array.isArray(object.translation))
           throw TypeError(
             ".transit_realtime.TranslatedString.translation: array expected"
           );
-        message.translation = [];
+        message.translation = Array(object.translation.length);
         for (let i = 0; i < object.translation.length; ++i) {
-          if (typeof object.translation[i] !== "object")
+          if (!$util.isObject(object.translation[i]))
             throw TypeError(
               ".transit_realtime.TranslatedString.translation: object expected"
             );
           message.translation[i] =
             $root.transit_realtime.TranslatedString.Translation.fromObject(
-              object.translation[i]
+              object.translation[i],
+              _depth + 1
             );
         }
       }
@@ -5318,17 +6340,20 @@ export const transit_realtime = ($root.transit_realtime = (() => {
      * @param {$protobuf.IConversionOptions} [options] Conversion options
      * @returns {Object.<string,*>} Plain object
      */
-    TranslatedString.toObject = function toObject(message, options) {
+    TranslatedString.toObject = function toObject(message, options, _depth) {
       if (!options) options = {};
+      if (_depth === undefined) _depth = 0;
+      if (_depth > $util.recursionLimit) throw Error("max depth exceeded");
       let object = {};
       if (options.arrays || options.defaults) object.translation = [];
       if (message.translation && message.translation.length) {
-        object.translation = [];
+        object.translation = Array(message.translation.length);
         for (let j = 0; j < message.translation.length; ++j)
           object.translation[j] =
             $root.transit_realtime.TranslatedString.Translation.toObject(
               message.translation[j],
-              options
+              options,
+              _depth + 1
             );
       }
       return object;
@@ -5346,41 +6371,52 @@ export const transit_realtime = ($root.transit_realtime = (() => {
     };
 
     /**
-     * Gets the default type url for TranslatedString
+     * Gets the type url for TranslatedString
      * @function getTypeUrl
      * @memberof transit_realtime.TranslatedString
      * @static
-     * @param {string} [typeUrlPrefix] your custom typeUrlPrefix(default "type.googleapis.com")
-     * @returns {string} The default type url
+     * @param {string} [prefix] Custom type url prefix, defaults to `"type.googleapis.com"`
+     * @returns {string} The type url
      */
-    TranslatedString.getTypeUrl = function getTypeUrl(typeUrlPrefix) {
-      if (typeUrlPrefix === undefined) {
-        typeUrlPrefix = "type.googleapis.com";
-      }
-      return typeUrlPrefix + "/transit_realtime.TranslatedString";
+    TranslatedString.getTypeUrl = function getTypeUrl(prefix) {
+      if (prefix === undefined) prefix = "type.googleapis.com";
+      return prefix + "/transit_realtime.TranslatedString";
     };
 
     TranslatedString.Translation = (function () {
       /**
        * Properties of a Translation.
-       * @memberof transit_realtime.TranslatedString
-       * @interface ITranslation
+       * @typedef {Object} transit_realtime.TranslatedString.Translation.$Properties
        * @property {string} text Translation text
        * @property {string|null} [language] Translation language
+       * @property {Array.<Uint8Array>} [$unknowns] Unknown fields preserved while decoding
+       */
+
+      /**
+       * Properties of a Translation.
+       * @memberof transit_realtime.TranslatedString
+       * @interface ITranslation
+       * @augments transit_realtime.TranslatedString.Translation.$Properties
+       * @deprecated Use transit_realtime.TranslatedString.Translation.$Properties instead.
+       */
+
+      /**
+       * Shape of a Translation.
+       * @typedef {transit_realtime.TranslatedString.Translation.$Properties} transit_realtime.TranslatedString.Translation.$Shape
        */
 
       /**
        * Constructs a new Translation.
        * @memberof transit_realtime.TranslatedString
        * @classdesc Represents a Translation.
-       * @implements ITranslation
        * @constructor
-       * @param {transit_realtime.TranslatedString.ITranslation=} [properties] Properties to set
+       * @param {transit_realtime.TranslatedString.Translation.$Properties=} [properties] Properties to set
+       * @property {Array.<Uint8Array>} [$unknowns] Unknown fields preserved while decoding
        */
       function Translation(properties) {
         if (properties)
           for (let keys = Object.keys(properties), i = 0; i < keys.length; ++i)
-            if (properties[keys[i]] != null)
+            if (properties[keys[i]] != null && keys[i] !== "__proto__")
               this[keys[i]] = properties[keys[i]];
       }
 
@@ -5405,8 +6441,12 @@ export const transit_realtime = ($root.transit_realtime = (() => {
        * @function create
        * @memberof transit_realtime.TranslatedString.Translation
        * @static
-       * @param {transit_realtime.TranslatedString.ITranslation=} [properties] Properties to set
+       * @param {transit_realtime.TranslatedString.Translation.$Properties=} [properties] Properties to set
        * @returns {transit_realtime.TranslatedString.Translation} Translation instance
+       * @type {{
+       *   (properties: transit_realtime.TranslatedString.Translation.$Shape): transit_realtime.TranslatedString.Translation & transit_realtime.TranslatedString.Translation.$Shape;
+       *   (properties?: transit_realtime.TranslatedString.Translation.$Properties): transit_realtime.TranslatedString.Translation;
+       * }}
        */
       Translation.create = function create(properties) {
         return new Translation(properties);
@@ -5417,18 +6457,26 @@ export const transit_realtime = ($root.transit_realtime = (() => {
        * @function encode
        * @memberof transit_realtime.TranslatedString.Translation
        * @static
-       * @param {transit_realtime.TranslatedString.ITranslation} message Translation message or plain object to encode
+       * @param {transit_realtime.TranslatedString.Translation.$Properties} message Translation message or plain object to encode
        * @param {$protobuf.Writer} [writer] Writer to encode to
        * @returns {$protobuf.Writer} Writer
        */
-      Translation.encode = function encode(message, writer) {
+      Translation.encode = function encode(message, writer, _depth) {
         if (!writer) writer = $Writer.create();
+        if (_depth === undefined) _depth = 0;
+        if (_depth > $util.recursionLimit) throw Error("max depth exceeded");
         writer.uint32(/* id 1, wireType 2 =*/ 10).string(message.text);
         if (
           message.language != null &&
           Object.hasOwnProperty.call(message, "language")
         )
           writer.uint32(/* id 2, wireType 2 =*/ 18).string(message.language);
+        if (
+          message.$unknowns != null &&
+          Object.hasOwnProperty.call(message, "$unknowns")
+        )
+          for (let i = 0; i < message.$unknowns.length; ++i)
+            writer.raw(message.$unknowns[i]);
         return writer;
       };
 
@@ -5437,12 +6485,15 @@ export const transit_realtime = ($root.transit_realtime = (() => {
        * @function encodeDelimited
        * @memberof transit_realtime.TranslatedString.Translation
        * @static
-       * @param {transit_realtime.TranslatedString.ITranslation} message Translation message or plain object to encode
+       * @param {transit_realtime.TranslatedString.Translation.$Properties} message Translation message or plain object to encode
        * @param {$protobuf.Writer} [writer] Writer to encode to
        * @returns {$protobuf.Writer} Writer
        */
       Translation.encodeDelimited = function encodeDelimited(message, writer) {
-        return this.encode(message, writer).ldelim();
+        return this.encode(
+          message,
+          writer && writer.len ? writer.fork() : writer
+        ).ldelim();
       };
 
       /**
@@ -5452,31 +6503,53 @@ export const transit_realtime = ($root.transit_realtime = (() => {
        * @static
        * @param {$protobuf.Reader|Uint8Array} reader Reader or buffer to decode from
        * @param {number} [length] Message length if known beforehand
-       * @returns {transit_realtime.TranslatedString.Translation} Translation
+       * @returns {transit_realtime.TranslatedString.Translation & transit_realtime.TranslatedString.Translation.$Shape} Translation
        * @throws {Error} If the payload is not a reader or valid buffer
        * @throws {$protobuf.util.ProtocolError} If required fields are missing
        */
-      Translation.decode = function decode(reader, length, error) {
+      Translation.decode = function decode(
+        reader,
+        length,
+        _end,
+        _depth,
+        _target
+      ) {
         if (!(reader instanceof $Reader)) reader = $Reader.create(reader);
+        if (_depth === undefined) _depth = 0;
+        if (_depth > $Reader.recursionLimit) throw Error("max depth exceeded");
         let end = length === undefined ? reader.len : reader.pos + length,
-          message = new $root.transit_realtime.TranslatedString.Translation();
+          message =
+            _target ||
+            new $root.transit_realtime.TranslatedString.Translation();
         while (reader.pos < end) {
-          let tag = reader.uint32();
-          if (tag === error) break;
-          switch (tag >>> 3) {
+          let start = reader.pos;
+          let tag = reader.tag();
+          if (tag === _end) {
+            _end = undefined;
+            break;
+          }
+          let wireType = tag & 7;
+          switch ((tag >>>= 3)) {
             case 1: {
+              if (wireType !== 2) break;
               message.text = reader.string();
-              break;
+              continue;
             }
             case 2: {
+              if (wireType !== 2) break;
               message.language = reader.string();
-              break;
+              continue;
             }
-            default:
-              reader.skipType(tag & 7);
-              break;
+          }
+          reader.skipType(wireType, _depth, tag);
+          if (!reader.discardUnknown) {
+            $util.makeProp(message, "$unknowns", false);
+            (message.$unknowns || (message.$unknowns = [])).push(
+              reader.raw(start, reader.pos)
+            );
           }
         }
+        if (_end !== undefined) throw Error("missing end group");
         if (!message.hasOwnProperty("text"))
           throw $util.ProtocolError("missing required 'text'", {
             instance: message,
@@ -5490,7 +6563,7 @@ export const transit_realtime = ($root.transit_realtime = (() => {
        * @memberof transit_realtime.TranslatedString.Translation
        * @static
        * @param {$protobuf.Reader|Uint8Array} reader Reader or buffer to decode from
-       * @returns {transit_realtime.TranslatedString.Translation} Translation
+       * @returns {transit_realtime.TranslatedString.Translation & transit_realtime.TranslatedString.Translation.$Shape} Translation
        * @throws {Error} If the payload is not a reader or valid buffer
        * @throws {$protobuf.util.ProtocolError} If required fields are missing
        */
@@ -5507,9 +6580,11 @@ export const transit_realtime = ($root.transit_realtime = (() => {
        * @param {Object.<string,*>} message Plain object to verify
        * @returns {string|null} `null` if valid, otherwise the reason why it is not
        */
-      Translation.verify = function verify(message) {
+      Translation.verify = function verify(message, _depth) {
         if (typeof message !== "object" || message === null)
           return "object expected";
+        if (_depth === undefined) _depth = 0;
+        if (_depth > $util.recursionLimit) return "max depth exceeded";
         if (!$util.isString(message.text)) return "text: string expected";
         if (message.language != null && message.hasOwnProperty("language"))
           if (!$util.isString(message.language))
@@ -5525,11 +6600,17 @@ export const transit_realtime = ($root.transit_realtime = (() => {
        * @param {Object.<string,*>} object Plain object
        * @returns {transit_realtime.TranslatedString.Translation} Translation
        */
-      Translation.fromObject = function fromObject(object) {
+      Translation.fromObject = function fromObject(object, _depth) {
         if (
           object instanceof $root.transit_realtime.TranslatedString.Translation
         )
           return object;
+        if (!$util.isObject(object))
+          throw TypeError(
+            ".transit_realtime.TranslatedString.Translation: object expected"
+          );
+        if (_depth === undefined) _depth = 0;
+        if (_depth > $util.recursionLimit) throw Error("max depth exceeded");
         let message = new $root.transit_realtime.TranslatedString.Translation();
         if (object.text != null) message.text = String(object.text);
         if (object.language != null) message.language = String(object.language);
@@ -5545,8 +6626,10 @@ export const transit_realtime = ($root.transit_realtime = (() => {
        * @param {$protobuf.IConversionOptions} [options] Conversion options
        * @returns {Object.<string,*>} Plain object
        */
-      Translation.toObject = function toObject(message, options) {
+      Translation.toObject = function toObject(message, options, _depth) {
         if (!options) options = {};
+        if (_depth === undefined) _depth = 0;
+        if (_depth > $util.recursionLimit) throw Error("max depth exceeded");
         let object = {};
         if (options.defaults) {
           object.text = "";
@@ -5571,18 +6654,16 @@ export const transit_realtime = ($root.transit_realtime = (() => {
       };
 
       /**
-       * Gets the default type url for Translation
+       * Gets the type url for Translation
        * @function getTypeUrl
        * @memberof transit_realtime.TranslatedString.Translation
        * @static
-       * @param {string} [typeUrlPrefix] your custom typeUrlPrefix(default "type.googleapis.com")
-       * @returns {string} The default type url
+       * @param {string} [prefix] Custom type url prefix, defaults to `"type.googleapis.com"`
+       * @returns {string} The type url
        */
-      Translation.getTypeUrl = function getTypeUrl(typeUrlPrefix) {
-        if (typeUrlPrefix === undefined) {
-          typeUrlPrefix = "type.googleapis.com";
-        }
-        return typeUrlPrefix + "/transit_realtime.TranslatedString.Translation";
+      Translation.getTypeUrl = function getTypeUrl(prefix) {
+        if (prefix === undefined) prefix = "type.googleapis.com";
+        return prefix + "/transit_realtime.TranslatedString.Translation";
       };
 
       return Translation;


### PR DESCRIPTION
## What changed

Revert the protobuf dependency group bump from PR #651:

- `protobufjs` 8.6.1 back to 8.5.0
- `protobufjs-cli` 2.5.2 back to 2.5.0
- regenerate the committed GTFS-RT protobuf artifacts with the reverted CLI

## Why

The current `edge` image is crashing in sandbox `vehicle-position-splitter-fi-jyvaskyla` with native heap corruption:

```text
malloc(): unaligned fastbin chunk detected
```

Sandbox is the only environment that has pulled the newest `edge` digest. Prod and staging are still running the previous digest and are stable. The bad image was built after the protobuf runtime/codegen bump and crashes during startup cache replay / splitting of GTFS-RT vehicle position messages.

This revert is intended to make `edge` safe again without pinning deployment overlays to image digests.

## Validation

- `npm ci`
- `npm run check-and-build`
